### PR TITLE
Backport generic embedded-app boilerplate from the Smart Send app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,50 @@ This template includes an updated setup consisting of:
 - [Basic Shopify app configuration](https://shopify.dev/docs/apps/build/cli-for-apps/app-configuration) to configure your apps locally with TOML files and deploy your changes using Shopify CLI.
 - Laravel 13 as the backend service
   - [Shopify managed installation](https://shopify.dev/docs/apps/build/authentication-authorization/app-installation): Simply configure relevant scopes in `shopify.app.toml`
-  - [App-specific webhook subscriptions](https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-vs-shop-specific-subscriptions): Webhooks are defined in `shopify.app.toml` including the
+  - [App-specific webhook subscriptions](https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-vs-shop-specific-subscriptions): Webhooks are defined in `shopify.app.toml`
 - [Shopify App Bridge](https://shopify.dev/docs/api/app-bridge) to add interactivity to your app.
 - [Shopify Polaris (Webcomponent)](https://shopify.dev/docs/beta/next-gen-dev-platform/polaris) to create a UI that adheres to Shopify's App Design Guidelines.
-- [`Shopify/shopify-app-php`](https://github.com/Shopify/shopify-app-php) for request verification, token handling, GraphQL and helper functions
+- [`Shopify/shopify-app-php`](https://github.com/Shopify/shopify-app-php) for request verification, token handling, GraphQL and helper functions — wired into a complete, ready-to-extend backend (see [What's included](#whats-included)).
+
+## What's included
+
+The template ships the generic backend boilerplate every embedded app needs, so
+you can delete the example page and start building features instead of plumbing:
+
+- **Embedded App Home authentication** — a custom `apphome` auth guard
+  (`App\Auth\Guards\ShopifyAppHomeGuard`) that verifies Shopify session/ID tokens
+  and performs [token exchange](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange)
+  for an offline access token. The `VerifyShopifyAppHome` middleware returns
+  App Bridge's own recovery responses (302 patch-id-token redirect / 401 retry)
+  on recoverable failures, and a wrong `SHOPIFY_CLIENT_ID`/`SHOPIFY_CLIENT_SECRET`
+  fails loudly instead of looping. The public `/auth/patch-id-token` route is
+  wired up too.
+- **Offline token storage + refresh** — `Shop` and `AccessToken` models with
+  migrations; tokens are refreshed proactively before expiry and reactively on a
+  401 (see `App\Services\Shopify\ShopifyShop`).
+- **GraphQL client** — `$shop->shopify()->graphql()->query(...)` with automatic
+  token refresh, throttle handling, and typed errors
+  (`GraphQLRequestException`). `$shop->shopify()->details()` is included as a
+  worked example.
+- **Webhook pipeline** — a single canonical `POST /webhooks/shopify` endpoint,
+  HMAC-verified by `VerifyShopifyWebhook`, routed by `WebhookDispatcher` with
+  built-in deduplication. The four mandatory topics are handled out of the box:
+  `app/uninstalled` plus the three GDPR compliance topics
+  (`customers/data_request`, `customers/redact`, `shop/redact`). Add your own
+  handlers in `App\Services\Shopify\Webhooks\Handlers`.
+- **Error references** — every request is tagged with a request id
+  (`AssignRequestIdMiddleware`) surfaced on the error page
+  (`resources/views/errors/500.blade.php`) so merchants can quote it to support.
+- **A test suite** — Unit + Feature tests covering the auth flow, webhook
+  HMAC/dedup/GDPR handling, token refresh, the GraphQL client and the exception
+  mapping, plus an opt-in Contract tier for real-store smoke tests.
+
+### First-install hook
+
+The first time a shop's offline token is created (i.e. on install/reinstall) is
+the place to run one-time setup — declaring metafield definitions, seeding
+defaults, registering extra webhooks, etc. Dispatch your jobs from the marked
+extension point in `ShopifyAppHomeGuard::createAndSaveNewAccessToken()`.
 
 ## Getting started
 
@@ -57,18 +97,33 @@ Generate an app key:
 php artisan key:generate
 ```
 
-And set the `SHOPIFY_CLIENT_ID` environment variable
+And set the Shopify credentials. `SHOPIFY_CLIENT_ID` is the app's Client ID (from
+`shopify.app.toml`); `SHOPIFY_CLIENT_SECRET` is the app's Client secret (from the
+Partner Dashboard, *Apps → your app → Client credentials*):
 
 ```
 // web/.env
 SHOPIFY_CLIENT_ID={INSERT-SHOPIFY-APP-CLIENT-ID}
+SHOPIFY_CLIENT_SECRET={INSERT-SHOPIFY-APP-CLIENT-SECRET}
 ```
 
-Alternatively run the following command from the root (not the `web` folder) to copy the value from `shopify.app.toml` to `.env`:
+Alternatively run the following command from the root (not the `web` folder) to copy the `client_id` from `shopify.app.toml` to `.env` (you still need to set the secret manually):
 
 ```shell
 grep 'client_id = ' shopify.app.toml | sed 's/client_id = "\(.*\)"/\1/' | xargs -I {} sed -i '' 's/^SHOPIFY_CLIENT_ID=.*/SHOPIFY_CLIENT_ID={}/' web/.env
 ```
+
+### Testing
+
+Run the bundled test suite from the `web` folder:
+
+```shell
+php artisan test                       # Unit + Feature (default)
+php artisan test --testsuite=Contract  # opt-in: smoke tests against a real store
+```
+
+The Contract tier authenticates against a real store and self-skips when no dev
+store / `TEST_STORE_*` credentials are available, so it is safe to run anywhere.
 
 ### Working with the template
 
@@ -84,5 +139,4 @@ See [here](https://shopify.dev/docs/apps/build/localize-your-app) for more detai
 
 ## Problems
 
-- Installation does not copy the `.env` or `.env.example` files (or any other hidden files)
 - NOTE: Provide a branch to `app init` by suffixing the url with `#foobar` for the branch named `foobar`

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,7 +1,24 @@
 # This file stores configurations for your Shopify app.
 # It must exist at the root of your app.
 
+[webhooks]
+api_version = "2026-01"
+
+# All webhook topics are delivered to a single canonical endpoint handled by
+# web/routes/webhooks.php (POST /webhooks/shopify), HMAC-verified by the
+# VerifyShopifyWebhook middleware and routed by WebhookDispatcher.
+#
+# IMPORTANT: the mandatory GDPR compliance topics are declared here as
+# `compliance_topics`. Do NOT also configure them in the Partner Dashboard /
+# Dev Dashboard — that would deliver each webhook twice.
+[[webhooks.subscriptions]]
+topics = [ "app/uninstalled" ]
+compliance_topics = [ "customers/redact", "customers/data_request", "shop/redact" ]
+uri = "/webhooks/shopify"
+
 [access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+# Declare the scopes your app needs, e.g. scopes = "read_products,read_orders".
 scopes = ""
 
 # [app_preferences]

--- a/web/app/Actions/Auth/CreateShopAction.php
+++ b/web/app/Actions/Auth/CreateShopAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Actions\Auth;
+
+use App\Models\Shop;
+use Illuminate\Support\Facades\Log;
+
+class CreateShopAction
+{
+    public function execute(string $shopDomain): Shop
+    {
+        Log::info('Creating new Shop-model', ['shop_domain' => $shopDomain]);
+
+        return Shop::create([
+            'shop_domain' => $shopDomain,
+        ]);
+    }
+}

--- a/web/app/Actions/Auth/SaveTokenExchangeAccessTokenAction.php
+++ b/web/app/Actions/Auth/SaveTokenExchangeAccessTokenAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions\Auth;
+
+use App\Enums\AccessTokenMode;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\Types\TokenExchangeAccessToken;
+
+class SaveTokenExchangeAccessTokenAction
+{
+    public function execute(Shop $shop, TokenExchangeAccessToken $accessToken): AccessToken
+    {
+        $model = $shop->accessToken()->updateOrCreate([], [
+            'token' => $accessToken->token,
+            'mode' => AccessTokenMode::Offline,
+            'scopes' => explode(',', $accessToken->scope),
+            'expires_at' => $accessToken->expires, // Note uses format 'Y-m-d\TH:i:s\Z'
+            'refresh_token' => $accessToken->refreshToken,
+            'refresh_token_expires_at' => $accessToken->refreshTokenExpires, // Note uses format 'Y-m-d\TH:i:s\Z'
+        ]);
+        $shop->load('accessToken'); // Because the relationship is already loaded, then we need to reload it here, otherwise the new relationship is not found
+
+        Log::info('Saved AccessToken-model', [
+            'shop_id' => $shop->id,
+            'access_token_id' => $model->id,
+        ]);
+
+        return $model;
+    }
+}

--- a/web/app/Actions/DeleteAccessTokenAction.php
+++ b/web/app/Actions/DeleteAccessTokenAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Shop;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Deletes the persisted offline access token for a shop.
+ *
+ * Used when the app is uninstalled (a stale token causes problems if the
+ * shop reinstalls) and as part of redacting shop data.
+ */
+class DeleteAccessTokenAction
+{
+    public function execute(Shop $shop): void
+    {
+        if ($shop->accessToken === null) {
+            return;
+        }
+
+        $shop->accessToken->delete();
+        $shop->unsetRelation('accessToken');
+
+        Log::info('Deleted access token for shop', [
+            'shop_id' => $shop->id,
+            'shop_domain' => $shop->shop_domain,
+        ]);
+    }
+}

--- a/web/app/Actions/MarkShopAsUninstalledAction.php
+++ b/web/app/Actions/MarkShopAsUninstalledAction.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Shop;
+use App\Workflows\DeleteShopWorkflow;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Marks a shop as uninstalled by stamping uninstalled_at.
+ *
+ * The Shop row itself is kept until the shop/redact compliance webhook
+ * arrives (~48 hours after uninstall), see {@see DeleteShopWorkflow}.
+ */
+class MarkShopAsUninstalledAction
+{
+    public function execute(Shop $shop): void
+    {
+        $shop->forceFill(['uninstalled_at' => now()])->save();
+
+        Log::info('Marked shop as uninstalled', [
+            'shop_id' => $shop->id,
+            'shop_domain' => $shop->shop_domain,
+        ]);
+    }
+}

--- a/web/app/Actions/RefreshAccessTokenAction.php
+++ b/web/app/Actions/RefreshAccessTokenAction.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Actions;
+
+use App\Actions\Auth\SaveTokenExchangeAccessTokenAction;
+use App\Events\ShopifyAccessTokenRefreshed;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\AccessTokenStillValidException;
+use App\Services\Shopify\ShopifyShopFactory;
+use Illuminate\Support\Facades\Log;
+
+class RefreshAccessTokenAction
+{
+    public function __construct(
+        protected ShopifyShopFactory $shopifyServiceFactory,
+        protected SaveTokenExchangeAccessTokenAction $saveTokenAction,
+    ) {}
+
+    public function execute(Shop $shop): AccessToken
+    {
+        $service = $this->shopifyServiceFactory->forShop($shop);
+
+        Log::info('Refreshing access token for shop', [
+            'shop_id' => $shop->id,
+        ]);
+
+        try {
+            $newToken = $service->refreshAccessToken();
+        } catch (AccessTokenStillValidException) {
+            // Shopify considers the current token still valid and declined to
+            // issue a new one. That is a no-op, not a failure: keep using the
+            // existing token. This happens routinely because offline tokens
+            // live only ~60 minutes, so the proactive buffer can fire while
+            // Shopify still regards the token as fresh.
+            Log::info('Access token still valid; keeping the existing one', [
+                'shop_id' => $shop->id,
+            ]);
+
+            return $shop->accessToken;
+        }
+
+        $savedToken = $this->saveTokenAction->execute($shop, $newToken);
+
+        ShopifyAccessTokenRefreshed::dispatch($shop);
+
+        Log::info('Access token refreshed and saved', [
+            'shop_id' => $shop->id,
+            'access_token_id' => $savedToken->id,
+        ]);
+
+        return $savedToken;
+    }
+}

--- a/web/app/Auth/Guards/ShopifyAppHomeGuard.php
+++ b/web/app/Auth/Guards/ShopifyAppHomeGuard.php
@@ -1,0 +1,497 @@
+<?php
+
+namespace App\Auth\Guards;
+
+use App\Actions\Auth\CreateShopAction;
+use App\Actions\Auth\SaveTokenExchangeAccessTokenAction;
+use App\Events\ShopifyAccessTokenRefreshed;
+use App\Http\Middleware\VerifyShopifyAppHome;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\ShopifyAuthException;
+use App\Services\Shopify\Exceptions\ShopifyCredentialMismatchException;
+use App\Services\Shopify\ShopifyRequestConverter;
+use App\Services\Shopify\ShopUtil;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\ResultWithExchangeableIdToken;
+use Shopify\App\Types\TokenExchangeResult;
+
+/**
+ * Guard for authenticating Shopify embedded app requests.
+ *
+ * This guard can be used to verify requests from shopify that contain
+ * an exchangeable ID token. It handles token exchange to refresh access tokens.
+ *
+ * Works with:
+ * - App home
+ * - Admin UI Extensions
+ * - POS UI Extensions
+ *
+ * Does not work with (requests without exchangeable id tokens):
+ * - Webhooks
+ * - App Proxy
+ * - Customer Account UI Extension
+ * - Checkout UI Extension
+ *
+ * @see https://github.com/Shopify/shopify-app-php/tree/main?tab=readme-ov-file#verifying-requests-with-exchangeable-id-tokens
+ * @see https://github.com/Shopify/shopify-app-php/tree/main?tab=readme-ov-file#verifying-requests-without-exchangeable-id-tokens
+ * @see https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/token-exchange
+ * @see https://shopify.dev/docs/apps/build/authentication-authorization/set-embedded-app-authorization?extension=javascript#session-token-in-the-request-header
+ */
+class ShopifyAppHomeGuard implements Guard
+{
+    public const DRIVER_NAME = 'shopify-app-home';
+
+    protected ?Authenticatable $user = null;
+
+    protected ?ResultWithExchangeableIdToken $verificationResult = null;
+
+    protected bool $credentialMismatchChecked = false;
+
+    public function __construct(
+        protected UserProvider $provider,
+        protected ShopifyApp $shopify,
+        protected Request $request
+    ) {}
+
+    /**
+     * Determine if the current request is authenticated.
+     */
+    public function check(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Determine if the current request is a guest.
+     */
+    public function guest(): bool
+    {
+        return ! $this->check();
+    }
+
+    /**
+     * Get the currently authenticated shop.
+     */
+    public function user(): ?Authenticatable
+    {
+        if ($this->user !== null) {
+            return $this->user;
+        }
+
+        Log::debug('Authenticating via Shopify App Home Guard');
+
+        $result = $this->verify();
+        $shopSubdomain = $result->shop;
+
+        if (! $result->ok) {
+            Log::warning('Invalid Shopify App Home authentication', [
+                'shop_subdomain' => $shopSubdomain,
+                'shopify_user_id' => $result->userId,
+                'log_code' => $result->log->code,
+                'log_detail' => $result->log->detail,
+            ]);
+
+            return null;
+        }
+
+        Log::debug('Shopify request is valid', [
+            'shop_subdomain' => $shopSubdomain,
+        ]);
+
+        $shop = $this->findOrCreateShop($result);
+        $this->handleAccessToken($shop);
+
+        Log::debug('Authenticated shop via Shopify App Home guard', [
+            'shop_subdomain' => $shopSubdomain,
+            'shop_id' => $shop->id,
+        ]);
+
+        $this->user = $shop;
+        $this->storeResultAsRequestAttributes($result);
+
+        return $this->user;
+    }
+
+    /**
+     * Get the ID for the currently authenticated shop.
+     */
+    public function id(): int|string|null
+    {
+        return $this->user()?->getAuthIdentifier();
+    }
+
+    /**
+     * Validate a shop's credentials (not used for token-based auth).
+     */
+    public function validate(array $credentials = []): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine if the guard has a user instance.
+     */
+    public function hasUser(): bool
+    {
+        return $this->user !== null;
+    }
+
+    /**
+     * Set the current user.
+     */
+    public function setUser(Authenticatable $user): static
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Verify the request, failing hard on a credential misconfiguration.
+     *
+     * Returns the raw verification result so the caller (the
+     * {@see VerifyShopifyAppHome} middleware) can emit the
+     * package's own response on recoverable failures — a 302 to the
+     * patch-id-token page, or a 401 carrying the retry header — exactly as
+     * Shopify recommends. A genuine wrong-credentials fingerprint instead throws
+     * {@see ShopifyCredentialMismatchException}: no session-token refresh can
+     * recover from it, so it must surface as a reported 500 rather than loop.
+     */
+    public function verify(): ResultWithExchangeableIdToken
+    {
+        $result = $this->verifyRequest();
+
+        if (! $result->ok && ! $this->credentialMismatchChecked) {
+            $this->credentialMismatchChecked = true;
+            $this->reportCredentialMismatch($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Verify the Shopify request.
+     */
+    protected function verifyRequest(): ResultWithExchangeableIdToken
+    {
+        if ($this->verificationResult !== null) {
+            return $this->verificationResult;
+        }
+
+        $shopifyRequest = ShopifyRequestConverter::toShopifyRequest($this->request);
+
+        $this->verificationResult = $this->shopify->verifyAppHomeReq(
+            $shopifyRequest,
+            appHomePatchIdTokenPath: config('shopify.patch_id_token_path'),
+        );
+
+        return $this->verificationResult;
+    }
+
+    /**
+     * Surface a credential misconfiguration as a clear, actionable error.
+     *
+     * When Shopify rejects the request in a way that fingerprints a wrong
+     * `SHOPIFY_CLIENT_ID` or `SHOPIFY_CLIENT_SECRET`, throw instead of returning
+     * null (which renders as a blank embedded page or an opaque 401). This is a
+     * "cannot happen" state — a deploy shipped mismatched credentials — so we
+     * fail loudly and let it be reported. The framework decides what the
+     * merchant sees: the full message under `APP_DEBUG`, a generic 500 in
+     * production. Only the precise credential-failure fingerprints throw;
+     * ordinary missing/expired tokens return without throwing so the middleware
+     * can emit the package's recovery response (the 302 patch redirect / 401 retry).
+     */
+    protected function reportCredentialMismatch(ResultWithExchangeableIdToken $result): void
+    {
+        $clientId = (string) config('shopify.client_id');
+        $code = $result->log->code;
+
+        // `invalid_aud` is the one fully trustworthy fingerprint: the package
+        // verified the signature with our secret (so the secret is right) and
+        // then found the token's `aud` != our client_id. A forged token cannot
+        // pass the signature check, so a wrong SHOPIFY_CLIENT_ID throws directly.
+        if ($code === 'invalid_aud') {
+            throw ShopifyCredentialMismatchException::fromVerification(
+                'invalid_aud',
+                $result->log->detail,
+                $clientId,
+            );
+        }
+
+        // A signature failure is reported as `invalid_id_token` on the bearer
+        // (XHR) path and as a patch-id-token redirect on the document path. Both
+        // are ambiguous — a wrong SHOPIFY_CLIENT_SECRET looks identical to a
+        // merely stale token — so inspect the presented token to tell them apart
+        // instead of throwing (which would 500 a recoverable session refresh).
+        if ($code === 'invalid_id_token' || $code === 'redirect_to_patch_id_token_page') {
+            $this->reportRejectedSecret($clientId);
+        }
+    }
+
+    /**
+     * Decide whether a signature-rejected id_token indicates a wrong secret.
+     *
+     * The token (from the Authorization bearer or the document `id_token` query)
+     * is decoded WITHOUT verifying its signature, purely to read `exp`. An
+     * unexpired token that still failed verification cannot be recovered by
+     * minting a fresh one — its signature does not match our configured secret —
+     * so that is a wrong SHOPIFY_CLIENT_SECRET. A stale (expired) or absent token
+     * is recoverable and left to the package's patch/retry flow.
+     *
+     * NOTE: a failed-signature token is untrusted, so its claims are
+     * attacker-controllable. The worst an attacker can do here is trigger this
+     * reported 500 (no access is ever granted); rely on the error tracker's
+     * grouping/rate-limiting to absorb any such noise.
+     */
+    protected function reportRejectedSecret(string $clientId): void
+    {
+        $idToken = $this->presentedIdToken();
+
+        if ($idToken === null) {
+            return; // Nothing to inspect — e.g. the normal first-hop bootstrap.
+        }
+
+        $claims = $this->decodeIdTokenClaims($idToken);
+
+        if ($claims === null) {
+            return; // Malformed — treat as a recoverable/garbage token.
+        }
+
+        $exp = $claims['exp'] ?? null;
+
+        if (is_numeric($exp) && (int) $exp > time()) {
+            throw ShopifyCredentialMismatchException::fromVerification(
+                'invalid_id_token',
+                'An unexpired ID token failed signature verification against the configured client secret.',
+                $clientId,
+            );
+        }
+    }
+
+    /**
+     * The id_token presented on the request, from the Authorization bearer
+     * (XHR/fetch) or, failing that, the document `id_token` query parameter.
+     */
+    private function presentedIdToken(): ?string
+    {
+        $authorization = (string) $this->request->header('Authorization', '');
+
+        if (str_starts_with($authorization, 'Bearer ')) {
+            $token = substr($authorization, 7);
+
+            return $token !== '' ? $token : null;
+        }
+
+        $queryToken = $this->request->query('id_token');
+
+        return is_string($queryToken) && $queryToken !== '' ? $queryToken : null;
+    }
+
+    /**
+     * Base64url-decode a JWT's payload segment without verifying the signature.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function decodeIdTokenClaims(string $jwt): ?array
+    {
+        $parts = explode('.', $jwt);
+
+        if (count($parts) !== 3) {
+            return null;
+        }
+
+        $base64 = strtr($parts[1], '-_', '+/');
+        $base64 .= str_repeat('=', (4 - strlen($base64) % 4) % 4);
+
+        $payload = base64_decode($base64, true);
+
+        if ($payload === false) {
+            return null;
+        }
+
+        $claims = json_decode($payload, true);
+
+        return is_array($claims) ? $claims : null;
+    }
+
+    /**
+     * Find or create the shop and handle token exchange.
+     */
+    protected function findOrCreateShop(ResultWithExchangeableIdToken $result): Shop
+    {
+        $shopDomain = ShopUtil::getDomainFromSubdomain($result->shop);
+
+        $shop = $this->provider->retrieveById($shopDomain);
+
+        if (! $shop) {
+            Log::info('No existing Shop-model found', [
+                'shop_domain' => $shopDomain,
+            ]);
+
+            $shop = resolve(CreateShopAction::class)->execute($shopDomain);
+        } else {
+            Log::debug('Existing Shop model found', [
+                'shop_id' => $shop->id,
+            ]);
+        }
+
+        if ($shop->shop_domain !== $shopDomain) {
+            // This should not be possible.
+            throw new \LogicException('Shop domain mismatch');
+        }
+
+        return $shop;
+    }
+
+    /**
+     * Make sure that the access token we have is valid, refresh it if needed and create a new one if we do not
+     * already have one.
+     */
+    protected function handleAccessToken(Shop $shop): void
+    {
+        if (! $shop->accessToken) {
+            Log::info('No existing AccessToken-model found', [
+                'shop_id' => $shop->id,
+            ]);
+
+            $this->createAndSaveNewAccessToken($shop);
+
+            return;
+        }
+
+        Log::debug('Checking if existing AccessToken-model needs refreshing', [
+            'shop_id' => $shop->id,
+        ]);
+        // refresh_token_expired: If there is a refresh token and that is expired, then it returns a 401 and the user must re-authenticate the app.
+        // token_still_valid: A simple OK TokenExchangeResult if the existing access token is still valid (the accessToken-parameter is null).
+        // configuration_error: 5xx response representing incorrect configuration of the app.
+        // server_error: 500 response when the package was not able to refresh the token.
+        // success: An OK TokenExchangeResult with a fresh accessToken-parameter is returned)
+        // NOTE: This does NOT verify that the correct scopes are present on the existing access token.
+        $refreshResult = $this->shopify->refreshTokenExchangedAccessToken(
+            $this->toTokenExchangeAccessTokenArray($shop->getShopifySubdomain(), $shop->accessToken)
+        );
+
+        if (! $refreshResult->ok) {
+            Log::error('Failed to refresh existing Shopify Access Token', [
+                'shop_id' => $shop->id,
+                'access_token_id' => $shop->accessToken->id,
+                'log_code' => $refreshResult->log?->code,
+                'log_detail' => $refreshResult->log?->detail,
+                'response_status' => $refreshResult->response->status,
+                'response_body' => $refreshResult->response->body,
+            ]);
+
+            throw ShopifyAuthException::fromResult($refreshResult, $shop);
+        }
+
+        // If the token was refreshed, then we need to handle the new access token
+        if ($refreshResult->accessToken) {
+            // A new access token was returned, update the shop record
+            Log::info('Refreshed Shopify Access Token', [
+                'shop_id' => $shop->id,
+                'access_token_id' => $shop->accessToken->id,
+                'log_code' => $refreshResult->log?->code,
+                'log_detail' => $refreshResult->log?->detail,
+            ]);
+
+            resolve(SaveTokenExchangeAccessTokenAction::class)->execute($shop, $refreshResult->accessToken);
+
+            ShopifyAccessTokenRefreshed::dispatch($shop, $refreshResult);
+        } else {
+            Log::debug('Existing AccessToken-model is still valid, no need to refresh it', [
+                'shop_id' => $shop->id,
+                'access_token_id' => $shop->accessToken->id,
+            ]);
+        }
+    }
+
+    protected function createAndSaveNewAccessToken(Shop $shop): void
+    {
+        // Exchange ID token for access token
+        Log::debug('Exchanging Shopify ID Token for Shopify Access Token');
+        $tokenExchangeResult = $this->exchangeIdToken($shop);
+
+        // Store the access token in the Shop model
+        Log::debug('Storing newly created Shopify Access Token', [
+            'shop_id' => $shop->id,
+        ]);
+        resolve(SaveTokenExchangeAccessTokenAction::class)->execute($shop, $tokenExchangeResult->accessToken);
+
+        // First offline access token means the app was just (re)installed.
+        // This is the extension point for first-install side effects: dispatch
+        // jobs here to declare metafield definitions, register additional
+        // webhooks, seed defaults, etc. e.g. `MyInstallJob::dispatch($shop);`
+    }
+
+    protected function exchangeIdToken(Shop $shop): TokenExchangeResult
+    {
+        Log::info('Exchanging Shopify ID Token for Shopify Access Token', [
+            'shop_id' => $shop->id,
+        ]);
+        $exchangeResult = $this->shopify->exchangeUsingTokenExchange(
+            accessMode: 'offline',
+            idToken: $this->verificationResult->idToken,
+            invalidTokenResponse: $this->verificationResult->newIdTokenResponse,
+        );
+
+        if (! $exchangeResult->ok) {
+            Log::error('Failed to exchange Shopify ID Token for Shopify Access Token', [
+                'shop_id' => $shop->id,
+                'log_code' => $exchangeResult->log?->code,
+                'log_detail' => $exchangeResult->log?->detail,
+                'response_status' => $exchangeResult->response->status,
+                'response_body' => $exchangeResult->response->body,
+            ]);
+
+            throw new \RuntimeException('Failed to exchange access token');
+        }
+
+        Log::info('Exchanged Shopify ID Token for Shopify Access Token', [
+            'shop_id' => $shop->id,
+            'log_code' => $exchangeResult->log?->code,
+            'log_detail' => $exchangeResult->log?->detail,
+        ]);
+
+        return $exchangeResult;
+    }
+
+    /**
+     * Store verification result data in the request for later use.
+     */
+    protected function storeResultAsRequestAttributes(ResultWithExchangeableIdToken $result): void
+    {
+        $this->request->attributes->set('shopify_shop', $result->shop); // eg 'smart-send-develop-eur'
+        $this->request->attributes->set('shopify_user_id', $result->userId); // eg 97834828052
+        // $this->request->attributes->set('shopify_id_token', $result->idToken); // sensitive information (JWT Session ID Token)
+        // $this->request->attributes->set('shopify_verification_result', $result); // sensitive information since it contain the idToken
+
+        Log::debug('Stored Shopify verification result in request attributes', $this->request->attributes->all());
+    }
+
+    private function toTokenExchangeAccessTokenArray(string $shopSubdomain, AccessToken $token): array
+    {
+        Log::info('Exchanging Shopify Access Token for Shopify Access Token', [
+            'shop' => $shopSubdomain,
+        ]);
+
+        // The shopify-app-php package appends `.myshopify.com` when building the
+        // OAuth token endpoint URL, so we must pass the subdomain only.
+        return [
+            'accessMode' => 'offline',
+            'shop' => $shopSubdomain,
+            'token' => $token->token,
+            'expires' => $token->expires_at?->format('Y-m-d\TH:i:s\Z'),
+            'scope' => implode(',', $token->scopes),
+            'refreshToken' => $token->refresh_token,
+            'refreshTokenExpires' => $token->refresh_token_expires_at?->format('Y-m-d\TH:i:s\Z'),
+            'user' => null,
+        ];
+    }
+}

--- a/web/app/Console/Commands/Concerns/HasShopOption.php
+++ b/web/app/Console/Commands/Concerns/HasShopOption.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands\Concerns;
+
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+use function Laravel\Prompts\search;
+
+trait HasShopOption
+{
+    protected function getShop(): Shop
+    {
+        $shopDomain = $this->option('shop');
+
+        if ($shopDomain) {
+            $shop = Shop::where('shop_domain', $shopDomain)->first();
+
+            if (! $shop) {
+                throw new ModelNotFoundException("Shop not found: {$shopDomain}");
+            }
+
+            return $shop;
+        }
+
+        $shopId = search(
+            label: 'Search for a shop',
+            options: fn (string $value) => strlen($value) > 0
+                ? Shop::search($value)->pluck('shop_domain', 'id')->all()
+                : [],
+        );
+
+        return Shop::findOrFail($shopId);
+    }
+}

--- a/web/app/Console/Commands/Shopify/StoreDetailsCommand.php
+++ b/web/app/Console/Commands/Shopify/StoreDetailsCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands\Shopify;
+
+use App\Console\Commands\Concerns\HasShopOption;
+use Illuminate\Console\Command;
+
+class StoreDetailsCommand extends Command
+{
+    use HasShopOption;
+
+    protected $signature = 'shopify:store-details {--shop= : The shop domain to fetch details for}';
+
+    protected $description = 'Fetch and display Shopify store details';
+
+    public function handle(): int
+    {
+        $shop = $this->getShop();
+        $data = $shop->shopify()->details();
+
+        if (empty($data)) {
+            $this->components->error('Shop not found.');
+
+            return self::FAILURE;
+        }
+
+        $this->components->twoColumnDetail('ID', $data['id']);
+        $this->components->twoColumnDetail('Name', $data['name']);
+        $this->components->twoColumnDetail('Domain', $data['myshopifyDomain']);
+        $this->components->twoColumnDetail('Currency', $data['currencyCode']);
+        $this->components->twoColumnDetail('Plan', $data['plan']['publicDisplayName'] ?? 'N/A');
+        $this->components->twoColumnDetail('Contact Email', $data['contactEmail']);
+
+        return self::SUCCESS;
+    }
+}

--- a/web/app/Enums/AccessTokenMode.php
+++ b/web/app/Enums/AccessTokenMode.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enums;
+
+enum AccessTokenMode: string
+{
+    case Offline = 'offline';
+}

--- a/web/app/Events/ShopifyAccessTokenRefreshed.php
+++ b/web/app/Events/ShopifyAccessTokenRefreshed.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Shop;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Shopify\App\Types\TokenExchangeResult;
+
+class ShopifyAccessTokenRefreshed
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Shop $shop,
+        public ?TokenExchangeResult $exchangeResult = null,
+    ) {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/web/app/Http/Controllers/Auth/PatchIdTokenController.php
+++ b/web/app/Http/Controllers/Auth/PatchIdTokenController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Services\Shopify\ShopifyRequestConverter;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\ShopifyApp;
+
+class PatchIdTokenController extends Controller
+{
+    public function __construct(
+        private ShopifyApp $shopify
+    ) {}
+
+    /**
+     * Handle the patch ID token request from Shopify.
+     *
+     * The user is redirected to this endpoint in access token edge cases
+     * like expiration or invalidity, ensuring the merchant experience is resilient.
+     * This is recommended in the README.md of the Shopify/shopify-app-php package
+     * but otherwise not mentioned in the docs.
+     *
+     * @see https://github.com/Shopify/shopify-app-php
+     */
+    public function __invoke(Request $request): Response
+    {
+        Log::warning('Handling Patch Id Token request');
+
+        $shopifyRequest = ShopifyRequestConverter::toShopifyRequest($request);
+        $result = $this->shopify->appHomePatchIdToken($shopifyRequest);
+
+        Log::info('Patch Id Token request handled', [
+            'log_code' => $result->log?->code,
+            'log_detail' => $result->log?->detail,
+            'response_status' => $result->response->status,
+            'response_body' => $result->response->body,
+        ]);
+
+        return ShopifyRequestConverter::toResponse($result->response, $result->log);
+    }
+}

--- a/web/app/Http/Controllers/Shopify/Webhooks/WebhookController.php
+++ b/web/app/Http/Controllers/Shopify/Webhooks/WebhookController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Shopify\Webhooks;
+
+use App\Http\Controllers\Controller;
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookDispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Single canonical endpoint for all Shopify webhook topics.
+ *
+ * HMAC verification is handled by the VerifyShopifyWebhook middleware before
+ * this controller runs. Topic routing happens in WebhookDispatcher - register
+ * new topic handlers there.
+ */
+class WebhookController extends Controller
+{
+    public function __invoke(Request $request, WebhookDispatcher $dispatcher): Response
+    {
+        $webhook = ShopifyWebhook::fromRequest($request);
+
+        Log::info('Handling Shopify webhook', [
+            'topic' => $webhook->topic,
+            'shop_domain' => $webhook->shopDomain,
+            'webhook_id' => $webhook->webhookId,
+            'api_version' => $webhook->apiVersion,
+        ]);
+
+        $dispatcher->dispatch($webhook);
+
+        return response()->noContent(Response::HTTP_OK);
+    }
+}

--- a/web/app/Http/Middleware/AssignRequestIdMiddleware.php
+++ b/web/app/Http/Middleware/AssignRequestIdMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Assigns a unique request id (UUID v7) to the request {@see Context} so every
+ * log line for the request carries it, and any error page can show the merchant
+ * the same id to quote to support.
+ */
+class AssignRequestIdMiddleware
+{
+    /** Context key (and log field) the request id is stored under. */
+    public const CONTEXT_KEY = 'request_id';
+
+    /**
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        Context::add(self::CONTEXT_KEY, (string) Str::uuid7());
+
+        return $next($request);
+    }
+}

--- a/web/app/Http/Middleware/ContentSecurityPolicyHeader.php
+++ b/web/app/Http/Middleware/ContentSecurityPolicyHeader.php
@@ -13,7 +13,7 @@ class ContentSecurityPolicyHeader
      *
      * @see https://shopify.dev/docs/apps/build/security/set-up-iframe-protection
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
@@ -27,10 +27,12 @@ class ContentSecurityPolicyHeader
 
         $shop = $request->query('shop', '');
 
-        $domainHost = $shop ? "https://$shop" : "*.myshopify.com";
-        $allowedDomains = "$domainHost https://admin.shopify.com";
+        $domainHost = $shop ? "https://$shop" : '*.myshopify.com';
+        $allowedDomains = "$domainHost https://admin.shopify.com https://extensions.shopifycdn.com";
 
         $response->headers->set('Content-Security-Policy', "frame-ancestors $allowedDomains;");
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
         return $response;
     }

--- a/web/app/Http/Middleware/VerifyShopifyAppHome.php
+++ b/web/app/Http/Middleware/VerifyShopifyAppHome.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Auth\Guards\ShopifyAppHomeGuard;
+use App\Services\Shopify\ShopifyRequestConverter;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifies an embedded App Home request and, on a recoverable failure, returns
+ * the package-provided response exactly as Shopify recommends — a 302 to the
+ * patch-id-token page (which drives App Bridge's session-token refresh) or a 401
+ * carrying the `X-Shopify-Retry-Invalid-Session-Request` header — rather than a
+ * generic 401 that strands the embedded UI on a blank page.
+ *
+ * The `ShopifyAppHomeGuard` cannot return an HTTP response (a Laravel guard only
+ * resolves a user), so the recommended "return shopifyResultToResponse($result)"
+ * step lives here. The guard still owns identity: it runs immediately after this
+ * middleware (via `auth:apphome`) and reuses the cached verification result.
+ *
+ * A genuine credential misconfiguration (wrong SHOPIFY_CLIENT_ID/SECRET) is not
+ * a recoverable session state — `verify()` throws there so it surfaces as a
+ * reported 500 instead of an endless patch-redirect loop.
+ *
+ * @see https://github.com/Shopify/shopify-app-php#verifying-requests-with-exchangeable-id-tokens
+ */
+class VerifyShopifyAppHome
+{
+    /**
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $guard = Auth::guard('apphome');
+
+        // Defensive: the apphome guard is always the Shopify guard, but guard
+        // resolution is configuration-driven, so fall through rather than fail
+        // if it has been swapped.
+        if (! $guard instanceof ShopifyAppHomeGuard) {
+            return $next($request);
+        }
+
+        // Respect an already-resolved identity (e.g. `actingAs()` in tests) —
+        // verifying again would ignore the injected user and hit the network.
+        if ($guard->hasUser()) {
+            return $next($request);
+        }
+
+        $result = $guard->verify();
+
+        if (! $result->ok) {
+            // Not authenticated, but recoverable: hand back the package's own
+            // response so App Bridge refreshes the session token and retries.
+            // (A genuine credential misconfiguration never reaches here — verify()
+            // throws above.) The request's error_reference rides along via Context.
+            Log::info('Embedded request not authenticated; returning Shopify recovery response', [
+                'log_code' => $result->log->code,
+                'response_status' => $result->response->status,
+            ]);
+
+            return ShopifyRequestConverter::toResponse($result->response, $result->log);
+        }
+
+        Log::debug('Embedded request verified; proceeding', [
+            'log_code' => $result->log->code,
+        ]);
+
+        return $next($request);
+    }
+}

--- a/web/app/Http/Middleware/VerifyShopifyWebhook.php
+++ b/web/app/Http/Middleware/VerifyShopifyWebhook.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\Shopify\ShopifyRequestConverter;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\ShopifyApp;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifies that an incoming webhook request originates from Shopify.
+ *
+ * The X-Shopify-Hmac-SHA256 header must contain a base64-encoded HMAC-SHA256
+ * digest of the raw request body, signed with the app's client secret.
+ * Verification is delegated to shopify-app-php which responds with
+ * 400 (missing HMAC header), 401 (invalid HMAC) or 405 (non-POST method).
+ *
+ * @see https://shopify.dev/docs/apps/build/webhooks/subscribe/https
+ */
+class VerifyShopifyWebhook
+{
+    public function __construct(protected ShopifyApp $shopifyApp) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $result = $this->shopifyApp->verifyWebhookReq(
+            ShopifyRequestConverter::toShopifyRequest($request)
+        );
+
+        if (! $result->ok) {
+            Log::warning('Shopify webhook verification failed', [
+                'code' => $result->log->code,
+                'detail' => $result->log->detail,
+            ]);
+
+            return ShopifyRequestConverter::toResponse($result->response, $result->log);
+        }
+
+        return $next($request);
+    }
+}

--- a/web/app/Models/AccessToken.php
+++ b/web/app/Models/AccessToken.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AccessTokenMode;
+use Database\Factories\AccessTokenFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Offline access token for a shop. One row per shop, rotated in place on refresh.
+ *
+ * Online (user-scoped) tokens are not persisted — when the app needs to act in
+ * the context of a request, it exchanges the session JWT on demand instead.
+ *
+ * Example: Expiring offline access token
+ * {
+ *   "access_token": "f85632530bf277ec9ac6f649fc327f17",
+ *   "scope": "write_orders,read_customers",
+ *   "expires_in": 3600,
+ *   "refresh_token": "shprt_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+ *   "refresh_token_expires_in": 7776000
+ * }
+ *
+ * Example: Non-expiring offline access token
+ * {
+ *   "access_token": "f85632530bf277ec9ac6f649fc327f17",
+ *   "scope": "write_orders,read_customers"
+ * }
+ *
+ * @see https://github.com/Shopify/shopify-app-php/tree/main?tab=readme-ov-file#app-home
+ * @see https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens
+ */
+class AccessToken extends Model
+{
+    /** @use HasFactory<AccessTokenFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'shop_id',
+        'token',
+        'mode',
+        'scopes',
+        'expires_at',
+        'refresh_token',
+        'refresh_token_expires_at',
+    ];
+
+    protected $hidden = [
+        'token',
+        'refresh_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'mode' => AccessTokenMode::class,
+            'scopes' => 'array',
+            'expires_at' => 'immutable_datetime',
+            'refresh_token_expires_at' => 'immutable_datetime',
+        ];
+    }
+
+    public function shop(): BelongsTo
+    {
+        return $this->belongsTo(Shop::class);
+    }
+
+    public function getScopeString(): string
+    {
+        return implode(',', $this->scopes);
+    }
+}

--- a/web/app/Models/Concerns/Searchable.php
+++ b/web/app/Models/Concerns/Searchable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+trait Searchable
+{
+    /**
+     * @return array<string>
+     */
+    abstract protected static function searchableColumns(): array;
+
+    public static function search(string $query = '', int $limit = 25): Collection
+    {
+        return static::query()
+            ->when($query, function (Builder $builder) use ($query) {
+                $builder->whereAny(static::searchableColumns(), 'LIKE', "%{$query}%");
+            })
+            ->limit($limit)
+            ->get();
+    }
+}

--- a/web/app/Models/Shop.php
+++ b/web/app/Models/Shop.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\Searchable;
+use App\Services\Shopify\ShopifyShop;
+use App\Services\Shopify\ShopifyShopFactory;
+use App\Services\Shopify\ShopUtil;
+use Database\Factories\ShopFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class Shop extends Authenticatable
+{
+    /** @use HasFactory<ShopFactory> */
+    use HasFactory;
+
+    use Searchable;
+
+    protected $fillable = [
+        'shop_domain',
+        'name',
+        'email',
+    ];
+
+    protected static function searchableColumns(): array
+    {
+        return ['shop_domain', 'name', 'email'];
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'uninstalled_at' => 'immutable_datetime',
+        ];
+    }
+
+    /**
+     * Get the unique identifier for the shop (used by auth system).
+     */
+    public function getAuthIdentifierName(): string
+    {
+        return 'shop_domain';
+    }
+
+    /**
+     * Get the unique identifier value for the shop.
+     */
+    public function getAuthIdentifier(): mixed
+    {
+        return $this->shop_domain;
+    }
+
+    /**
+     * Get the Shopify shop subdomain (without .myshopify.com).
+     */
+    public function getShopifySubdomain(): string
+    {
+        return ShopUtil::getSubdomainFromDomain($this->shop_domain);
+    }
+
+    public function accessToken(): HasOne
+    {
+        return $this->hasOne(AccessToken::class);
+    }
+
+    public function shopify(): ShopifyShop
+    {
+        return app(ShopifyShopFactory::class)->forShop($this);
+    }
+}

--- a/web/app/Providers/AppServiceProvider.php
+++ b/web/app/Providers/AppServiceProvider.php
@@ -2,7 +2,12 @@
 
 namespace App\Providers;
 
+use App\Auth\Guards\ShopifyAppHomeGuard;
+use App\Services\Shopify\ShopifyShopFactory;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
+use Shopify\App\ShopifyApp;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +16,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(ShopifyApp::class, fn () => new ShopifyApp(
+            clientId: config('shopify.client_id'),
+            clientSecret: config('shopify.client_secret'),
+        ));
+
+        $this->app->singleton(ShopifyShopFactory::class, fn (Application $app) => new ShopifyShopFactory(
+            shopifyApp: $app->make(ShopifyApp::class),
+        ));
     }
 
     /**
@@ -19,6 +31,23 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->registerShopifyAuthGuards();
+    }
+
+    /**
+     * Register the Shopify authentication guard.
+     *
+     * This guard handles both session tokens (from initial page loads)
+     * and bearer tokens (from API requests) via verifyAppHomeReq().
+     */
+    protected function registerShopifyAuthGuards(): void
+    {
+        Auth::extend(ShopifyAppHomeGuard::DRIVER_NAME, function (Application $app, $name, array $config) {
+            return new ShopifyAppHomeGuard(
+                Auth::createUserProvider($config['provider']),
+                $app->make(ShopifyApp::class),
+                $app['request']
+            );
+        });
     }
 }

--- a/web/app/Services/Shopify/Exceptions/AccessTokenStillValidException.php
+++ b/web/app/Services/Shopify/Exceptions/AccessTokenStillValidException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use RuntimeException;
+
+class AccessTokenStillValidException extends RuntimeException
+{
+    public function __construct(string $message = 'Access token is still valid, no refresh was performed')
+    {
+        parent::__construct($message);
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/GraphQLRequestException.php
+++ b/web/app/Services/Shopify/Exceptions/GraphQLRequestException.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use App\Services\Shopify\GraphQL\GraphQLError;
+use RuntimeException;
+use Shopify\App\Types\GQLResult;
+
+class GraphQLRequestException extends RuntimeException implements ShopifyGraphQLExceptionInterface
+{
+    /** @var array<GraphQLError> */
+    private array $graphQLErrors;
+
+    /**
+     * @param  array<GraphQLError>  $graphQLErrors
+     */
+    public function __construct(
+        string $message,
+        protected string $shopDomain,
+        protected GQLResult $result,
+        array $graphQLErrors = [],
+    ) {
+        parent::__construct(message: $message);
+        $this->graphQLErrors = $graphQLErrors;
+    }
+
+    public static function fromResult(string $shopDomain, GQLResult $result): self
+    {
+        $errors = self::parseErrorsFromBody($result);
+        $message = $result->log?->detail ?? 'Shopify GraphQL request failed';
+
+        if (! empty($errors)) {
+            $message = $errors[0]->message;
+        }
+
+        return new self(
+            message: $message,
+            shopDomain: $shopDomain,
+            result: $result,
+            graphQLErrors: $errors,
+        );
+    }
+
+    public function getShopDomain(): string
+    {
+        return $this->shopDomain;
+    }
+
+    public function getRawResult(): GQLResult
+    {
+        return $this->result;
+    }
+
+    /**
+     * @return array<GraphQLError>
+     */
+    public function getErrors(): array
+    {
+        return $this->graphQLErrors;
+    }
+
+    public function getLogCode(): ?string
+    {
+        return $this->result->log?->code;
+    }
+
+    /**
+     * @return array<GraphQLError>
+     */
+    private static function parseErrorsFromBody(GQLResult $result): array
+    {
+        if ($result->log?->code !== 'graphql_errors') {
+            return [];
+        }
+
+        $body = json_decode($result->response->body, true);
+        $errors = $body['errors'] ?? [];
+
+        return array_map(
+            fn (array $error) => GraphQLError::fromArray($error),
+            $errors,
+        );
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/MissingAccessTokenException.php
+++ b/web/app/Services/Shopify/Exceptions/MissingAccessTokenException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use InvalidArgumentException;
+
+class MissingAccessTokenException extends InvalidArgumentException implements ShopifyGraphQLExceptionInterface
+{
+    public function __construct(
+        protected ?string $shopDomain = null,
+        string $message = 'Shop does not have an access token',
+    ) {
+        parent::__construct($message);
+    }
+
+    public function getShopDomain(): ?string
+    {
+        return $this->shopDomain;
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/MissingApiVersionException.php
+++ b/web/app/Services/Shopify/Exceptions/MissingApiVersionException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use InvalidArgumentException;
+
+class MissingApiVersionException extends InvalidArgumentException implements ShopifyGraphQLExceptionInterface
+{
+    public function __construct(
+        protected ?string $shopDomain = null,
+        string $message = 'SHOPIFY_API_VERSION is set but empty. Set it to a Shopify Admin API version (e.g. 2026-01) or remove it to use the configured default.',
+    ) {
+        parent::__construct($message);
+    }
+
+    public function getShopDomain(): ?string
+    {
+        return $this->shopDomain;
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyAuthException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyAuthException.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use App\Models\Shop;
+use Exception;
+use Shopify\App\Types\TokenExchangeResult;
+use Throwable;
+
+/**
+ * Base class for any failure originating from the shopify-app-php package's
+ * token-exchange / refresh flow. Concrete subclasses correspond to the
+ * `log_code` values returned by the package.
+ *
+ * Subclasses opt into one of two shared response strategies via the
+ * intermediate abstracts {@see ShopifyReauthRequiredException} and
+ * {@see ShopifyAuthTransientException}, or fall through to the default
+ * 500 handling on this base for unexpected codes.
+ */
+abstract class ShopifyAuthException extends Exception
+{
+    public function __construct(
+        public readonly TokenExchangeResult $result,
+        public readonly ?Shop $shop = null,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(
+            message: sprintf(
+                '[%s] %s',
+                $result->log?->code ?? 'unknown',
+                $result->log?->detail ?? 'Shopify authentication failed.',
+            ),
+            previous: $previous,
+        );
+    }
+
+    /**
+     * Translate a not-ok TokenExchangeResult into the matching exception type.
+     *
+     * Centralised so call sites (the auth guard and ShopifyShop) stay DRY and
+     * any new `log_code` introduced by the package surfaces consistently as
+     * a {@see ShopifyUnexpectedAuthException}.
+     */
+    public static function fromResult(TokenExchangeResult $result, ?Shop $shop = null): self
+    {
+        return match ($result->log?->code) {
+            'refresh_token_expired' => new ShopifyRefreshTokenExpiredException($result, $shop),
+            'invalid_grant' => new ShopifyInvalidGrantException($result, $shop),
+            'invalid_client' => new ShopifyInvalidClientException($result, $shop),
+            'network_error' => new ShopifyNetworkErrorException($result, $shop),
+            'server_error' => new ShopifyServerErrorException($result, $shop),
+            default => new ShopifyUnexpectedAuthException($result, $shop),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        return [
+            'shop_id' => $this->shop?->id,
+            'shop_domain' => $this->shop?->shop_domain,
+            'log_code' => $this->result->log?->code,
+            'log_detail' => $this->result->log?->detail,
+            'response_status' => $this->result->response?->status,
+        ];
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyAuthTransientException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyAuthTransientException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Thrown when token refresh fails for reasons we expect to be temporary
+ * (Shopify upstream 5xx after retries, or our network can't reach Shopify).
+ *
+ * Reported at warning level — these happen and shouldn't page oncall, but we
+ * want them visible enough to spot a pattern.
+ *
+ * Render returns 503 + Retry-After in production. In non-production we return
+ * null so APP_DEBUG=true falls through to Ignition, which surfaces the concrete
+ * exception class name (e.g. ShopifyNetworkErrorException) and the package's
+ * log_detail directly to the developer.
+ */
+abstract class ShopifyAuthTransientException extends ShopifyAuthException
+{
+    public function report(): void
+    {
+        Log::warning('Shopify auth transient failure', $this->context());
+    }
+
+    public function render(Request $request): ?Response
+    {
+        if (! app()->environment('production')) {
+            return null;
+        }
+
+        return new Response('Service temporarily unavailable.', 503, [
+            'Retry-After' => '30',
+        ]);
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyCredentialMismatchException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyCredentialMismatchException.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when Shopify rejects an embedded request in a way that fingerprints a
+ * misconfiguration of the app's own credentials: a `SHOPIFY_CLIENT_ID` or
+ * `SHOPIFY_CLIENT_SECRET` that does not match the app the store installed.
+ *
+ * The usual cause is re-linking the app (the `client_id` in `shopify.app.toml`
+ * changes) without re-syncing `web/.env`. This is a "cannot happen in a healthy
+ * deploy" state, so the guard always throws it — the app is wholly unusable for
+ * every merchant until the credentials are fixed. The framework decides what is
+ * shown: the full message under `APP_DEBUG`, a generic 500 in production. The
+ * exception is still reported either way, so we get alerted.
+ *
+ * Shopify's verifier reports a distinct code per credential, which we translate
+ * into an actionable hint:
+ *
+ * - `invalid_aud`      → id_token `aud` claim ≠ configured client_id → SHOPIFY_CLIENT_ID
+ * - `invalid_id_token` → id_token signature failed to verify         → SHOPIFY_CLIENT_SECRET
+ *
+ * Only the public client_id is ever included (in the log context, never the
+ * merchant-facing response). The client secret is never referenced.
+ */
+class ShopifyCredentialMismatchException extends RuntimeException
+{
+    private function __construct(
+        string $message,
+        public readonly string $reasonCode,
+        public readonly string $configuredClientId,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function fromVerification(string $code, string $detail, string $configuredClientId): self
+    {
+        $culprit = match ($code) {
+            'invalid_aud' => 'SHOPIFY_CLIENT_ID',
+            'invalid_id_token' => 'SHOPIFY_CLIENT_SECRET',
+            default => 'SHOPIFY_CLIENT_ID and/or SHOPIFY_CLIENT_SECRET',
+        };
+
+        return new self(sprintf(
+            "Shopify rejected the embedded request with `%s` (%s).\n\n"
+            .'This almost always means the env %s does not match the app this store installed. ',
+            $code,
+            $detail,
+            $culprit,
+        ), $code, $configuredClientId);
+    }
+
+    /**
+     * Structured context merged into the log record when this exception is
+     * reported, so the reason and (public) client_id are queryable without
+     * parsing the message. No secret is ever included.
+     *
+     * @return array<string, string>
+     */
+    public function context(): array
+    {
+        return [
+            'shopify_reason_code' => $this->reasonCode,
+            'configured_client_id' => $this->configuredClientId,
+        ];
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyGraphQLExceptionInterface.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyGraphQLExceptionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+interface ShopifyGraphQLExceptionInterface
+{
+    public function getShopDomain(): ?string;
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyInvalidClientException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyInvalidClientException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+/**
+ * Maps to package log_code `invalid_client`.
+ *
+ * The OAuth endpoint reports that our client credentials are invalid or the
+ * app has been uninstalled from the shop. In practice this is overwhelmingly
+ * "uninstalled" once an app is live, so we treat it as a re-auth case rather
+ * than a configuration bug. Genuine bad credentials show up here too but get
+ * caught by the same flow on the next install attempt.
+ */
+final class ShopifyInvalidClientException extends ShopifyReauthRequiredException {}

--- a/web/app/Services/Shopify/Exceptions/ShopifyInvalidGrantException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyInvalidGrantException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+/**
+ * Maps to package log_code `invalid_grant`.
+ *
+ * Shopify's OAuth endpoint rejected the refresh token: it has been revoked,
+ * was never valid, or the merchant uninstalled and re-installed (issuing a
+ * new grant). The merchant must re-authenticate.
+ */
+final class ShopifyInvalidGrantException extends ShopifyReauthRequiredException {}

--- a/web/app/Services/Shopify/Exceptions/ShopifyNetworkErrorException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyNetworkErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+/**
+ * Maps to package log_code `network_error`.
+ *
+ * Guzzle threw a RequestException trying to reach Shopify's OAuth endpoint —
+ * DNS, TLS, connection reset, tunnel hiccup, etc. Transient; the next request
+ * usually succeeds.
+ */
+final class ShopifyNetworkErrorException extends ShopifyAuthTransientException {}

--- a/web/app/Services/Shopify/Exceptions/ShopifyReauthRequiredException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyReauthRequiredException.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Thrown when the merchant must re-authenticate (the offline refresh token is
+ * dead, the grant was revoked, or the app was uninstalled).
+ *
+ * Concrete subclasses are the actual `log_code` values; this intermediate
+ * carries the shared rendering + reporting behaviour.
+ *
+ * Production response shape follows the App Bridge "reauthorize" convention:
+ * a 401 with the X-Shopify-API-Request-Failure-Reauthorize headers. App Bridge
+ * (loaded by the embedded iframe) reads those headers and triggers a top-level
+ * re-auth navigation. For non-XHR document loads we still return the 401 — the
+ * App Bridge bootstrap on the host page handles the redirect.
+ *
+ * Not reported: a refresh-token death is a normal lifecycle event for long-lived
+ * installs, not a bug to page oncall about.
+ */
+abstract class ShopifyReauthRequiredException extends ShopifyAuthException
+{
+    public function report(): bool
+    {
+        Log::info('Shopify re-authentication required', $this->context());
+
+        return false;
+    }
+
+    public function render(Request $request): Response
+    {
+        return new Response('', 401, [
+            'X-Shopify-API-Request-Failure-Reauthorize' => '1',
+            'X-Shopify-API-Request-Failure-Reauthorize-Url' => $this->reauthorizeUrl(),
+        ]);
+    }
+
+    /**
+     * Where App Bridge should send the merchant to re-acquire a valid token.
+     *
+     * For token-exchange apps the canonical recovery is to re-load the embedded
+     * app entry-point — Shopify Admin issues a fresh id_token, which the guard
+     * then exchanges for a new access token. A dedicated `/auth` route is only
+     * needed if we ever fall back to the classic OAuth grant flow.
+     */
+    protected function reauthorizeUrl(): string
+    {
+        return '/';
+    }
+}

--- a/web/app/Services/Shopify/Exceptions/ShopifyRefreshTokenExpiredException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyRefreshTokenExpiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+/**
+ * Maps to package log_code `refresh_token_expired`.
+ *
+ * The stored refresh token's `refreshTokenExpires` timestamp is in the past,
+ * so the package short-circuits before hitting Shopify. The merchant must
+ * re-authenticate to get a fresh token pair.
+ */
+final class ShopifyRefreshTokenExpiredException extends ShopifyReauthRequiredException {}

--- a/web/app/Services/Shopify/Exceptions/ShopifyServerErrorException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyServerErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+/**
+ * Maps to package log_code `server_error`.
+ *
+ * Shopify's OAuth endpoint returned 5xx and the package's internal retry
+ * budget was exhausted. Transient on Shopify's side.
+ */
+final class ShopifyServerErrorException extends ShopifyAuthTransientException {}

--- a/web/app/Services/Shopify/Exceptions/ShopifyUnexpectedAuthException.php
+++ b/web/app/Services/Shopify/Exceptions/ShopifyUnexpectedAuthException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Shopify\Exceptions;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Catch-all for any log_code the package returns that we do not have an
+ * explicit subclass for — currently `configuration_error`, `refresh_error`,
+ * `unexpected_error`, and anything the package may introduce in the future.
+ *
+ * These represent "we have no recipe for this": real bugs (wrong client_id /
+ * secret), unknown OAuth errors, or genuinely novel failures. Always reported
+ * at error level; the default Laravel handler renders 500 (with full Ignition
+ * detail in APP_DEBUG, generic error page in production).
+ */
+final class ShopifyUnexpectedAuthException extends ShopifyAuthException
+{
+    public function report(): void
+    {
+        Log::error('Unexpected Shopify auth failure', $this->context());
+    }
+}

--- a/web/app/Services/Shopify/GraphQL/GraphQLError.php
+++ b/web/app/Services/Shopify/GraphQL/GraphQLError.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Shopify\GraphQL;
+
+readonly class GraphQLError
+{
+    /**
+     * @param  array<array{line: int, column: int}>|null  $locations
+     * @param  array<string|int>|null  $path
+     * @param  array<string, mixed>|null  $extensions
+     */
+    public function __construct(
+        public string $message,
+        public ?array $locations = null,
+        public ?array $path = null,
+        public ?array $extensions = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            message: $data['message'] ?? '',
+            locations: $data['locations'] ?? null,
+            path: $data['path'] ?? null,
+            extensions: $data['extensions'] ?? null,
+        );
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->extensions['code'] ?? null;
+    }
+}

--- a/web/app/Services/Shopify/GraphQL/ShopifyGraphQLClient.php
+++ b/web/app/Services/Shopify/GraphQL/ShopifyGraphQLClient.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services\Shopify\GraphQL;
+
+use App\Services\Shopify\Exceptions\GraphQLRequestException;
+use Closure;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\GQLResult;
+
+/**
+ * Thin wrapper around shopify-app-php's adminGraphQLRequest that:
+ *  - reactively refreshes the access token on a 401 and retries once
+ *  - surfaces GraphQL errors (which the package strips from `data` into
+ *    `response->body`) as a thrown {@see GraphQLRequestException}
+ *
+ * 429 retries with `Retry-After` and 5xx exponential backoff are handled
+ * inside the package itself, so no rate limiting lives here.
+ */
+class ShopifyGraphQLClient
+{
+    /**
+     * @param  Closure():string  $refresher  Returns the new access token string after refreshing.
+     */
+    public function __construct(
+        protected ShopifyApp $shopifyApp,
+        protected string $shopDomain,
+        protected string $accessToken,
+        protected string $apiVersion,
+        protected Closure $refresher,
+    ) {}
+
+    /**
+     * Execute a GraphQL query.
+     *
+     * @param  array<string, mixed>|null  $variables
+     *
+     * @throws GraphQLRequestException
+     */
+    public function query(string $query, ?array $variables = null): ShopifyGraphQLResult
+    {
+        $result = $this->request($query, $variables);
+
+        if (! $result->ok && $result->log->code === 'unauthorized') {
+            Log::info('Access token rejected by Shopify; refreshing and retrying once', [
+                'shop_domain' => $this->shopDomain,
+            ]);
+
+            $this->accessToken = ($this->refresher)();
+            $result = $this->request($query, $variables);
+        }
+
+        if (! $result->ok) {
+            throw GraphQLRequestException::fromResult($this->shopDomain, $result);
+        }
+
+        return new ShopifyGraphQLResult($result);
+    }
+
+    /**
+     * Execute a GraphQL mutation (semantic alias for query).
+     *
+     * @param  array<string, mixed>|null  $variables
+     *
+     * @throws GraphQLRequestException
+     */
+    public function mutate(string $mutation, ?array $variables = null): ShopifyGraphQLResult
+    {
+        return $this->query($mutation, $variables);
+    }
+
+    public function getShopDomain(): string
+    {
+        return $this->shopDomain;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $variables
+     */
+    private function request(string $query, ?array $variables): GQLResult
+    {
+        Log::debug('Executing Shopify GraphQL query', [
+            'shop_domain' => $this->shopDomain,
+        ]);
+
+        return $this->shopifyApp->adminGraphQLRequest(
+            query: $query,
+            shop: $this->shopDomain,
+            accessToken: $this->accessToken,
+            apiVersion: $this->apiVersion,
+            variables: $variables,
+        );
+    }
+}

--- a/web/app/Services/Shopify/GraphQL/ShopifyGraphQLResult.php
+++ b/web/app/Services/Shopify/GraphQL/ShopifyGraphQLResult.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services\Shopify\GraphQL;
+
+use App\Services\Shopify\Exceptions\GraphQLRequestException;
+use Shopify\App\Types\GQLResult;
+
+/**
+ * Wraps a successful (ok=true) GQLResult. Error responses are thrown as
+ * {@see GraphQLRequestException} from the
+ * client, so this object always carries data.
+ */
+readonly class ShopifyGraphQLResult
+{
+    public function __construct(
+        protected GQLResult $result,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function data(): array
+    {
+        return $this->result->data ?? [];
+    }
+
+    public function throttleStatus(): ?ThrottleStatus
+    {
+        $status = $this->result->extensions['cost']['throttleStatus'] ?? null;
+
+        return ThrottleStatus::fromArray($status);
+    }
+
+    public function raw(): GQLResult
+    {
+        return $this->result;
+    }
+}

--- a/web/app/Services/Shopify/GraphQL/ThrottleStatus.php
+++ b/web/app/Services/Shopify/GraphQL/ThrottleStatus.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services\Shopify\GraphQL;
+
+readonly class ThrottleStatus
+{
+    public function __construct(
+        public int $maximumAvailable,
+        public int $currentlyAvailable,
+        public float $restoreRate,
+    ) {}
+
+    public static function fromArray(?array $data): ?self
+    {
+        if ($data === null) {
+            return null;
+        }
+
+        return new self(
+            maximumAvailable: (int) ($data['maximumAvailable'] ?? 0),
+            currentlyAvailable: (int) ($data['currentlyAvailable'] ?? 0),
+            restoreRate: (float) ($data['restoreRate'] ?? 0),
+        );
+    }
+
+    public function isLow(int $threshold = 100): bool
+    {
+        return $this->currentlyAvailable < $threshold;
+    }
+
+    public function getWaitMilliseconds(int $targetPoints = 100): int
+    {
+        if ($this->currentlyAvailable >= $targetPoints || $this->restoreRate <= 0) {
+            return 0;
+        }
+
+        return (int) (($targetPoints - $this->currentlyAvailable) / $this->restoreRate * 1000);
+    }
+}

--- a/web/app/Services/Shopify/ShopUtil.php
+++ b/web/app/Services/Shopify/ShopUtil.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Shopify;
+
+use Illuminate\Support\Str;
+
+class ShopUtil
+{
+    /**
+     * Examples:
+     * 1. example-store.myshopify.com => example-store
+     * 2. https://example-store.myshopify.com => example-store
+     */
+    public static function getSubdomainFromDomain(string $url): string
+    {
+        return Str::of($url)
+            ->before('.myshopify.com')
+            ->__toString();
+    }
+
+    /**
+     * Example: example-store => example-store.myshopify.com
+     */
+    public static function getDomainFromSubdomain(string $subdomain): string
+    {
+        return $subdomain.'.myshopify.com';
+    }
+}

--- a/web/app/Services/Shopify/ShopifyRequestConverter.php
+++ b/web/app/Services/Shopify/ShopifyRequestConverter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services\Shopify;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\Types\LogWithReq;
+use Shopify\App\Types\ResponseInfo;
+
+class ShopifyRequestConverter
+{
+    /**
+     * Convert a Laravel Request to the format expected by shopify-app-php.
+     *
+     * Laravel exposes each header as an array of values, but shopify-app-php
+     * expects a single string value per header (e.g. when comparing the
+     * X-Shopify-Hmac-SHA256 header), so multi-value headers are joined with a
+     * comma per RFC 9110.
+     *
+     * @return array{method: string, headers: array<string, string>, url: string, body: string}
+     */
+    public static function toShopifyRequest(Request $request): array
+    {
+        $headers = array_map(
+            fn (array $values): string => implode(', ', $values),
+            $request->headers->all(),
+        );
+
+        return [
+            'method' => $request->method(),
+            'headers' => $headers,
+            'url' => $request->fullUrl(),
+            'body' => $request->getContent(),
+        ];
+    }
+
+    /**
+     * Convert a shopify-app-php result to a Laravel Response.
+     */
+    public static function toResponse(
+        ResponseInfo $responseInfo,
+        LogWithReq $log
+    ): Response {
+        Log::info('Converting Shopify ResponseInfo to Response', [
+            'code' => $log->code,
+            'detail' => $log->detail,
+        ]);
+
+        $headers = is_array($responseInfo->headers) ? $responseInfo->headers : (array) $responseInfo->headers;
+
+        return response($responseInfo->body, $responseInfo->status)
+            ->withHeaders($headers);
+    }
+}

--- a/web/app/Services/Shopify/ShopifyShop.php
+++ b/web/app/Services/Shopify/ShopifyShop.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Services\Shopify;
+
+use App\Actions\RefreshAccessTokenAction;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\AccessTokenStillValidException;
+use App\Services\Shopify\Exceptions\MissingAccessTokenException;
+use App\Services\Shopify\Exceptions\MissingApiVersionException;
+use App\Services\Shopify\Exceptions\ShopifyAuthException;
+use App\Services\Shopify\GraphQL\ShopifyGraphQLClient;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\TokenExchangeAccessToken;
+
+/**
+ * Single entry point for Shopify operations on behalf of a shop, scoped to its
+ * persisted offline access token.
+ *
+ * Always obtained via `$shop->shopify()` (or the {@see ShopifyShopFactory}).
+ * Background callers (queue jobs, webhook handlers, console commands) use this
+ * for GraphQL; request-time callers may also use it, but online tokens are
+ * never persisted — see {@see AccessToken}.
+ */
+class ShopifyShop
+{
+    /**
+     * How close to expiry (in minutes) an offline token may be before we
+     * proactively refresh it. Kept small on purpose: offline tokens live only
+     * ~60 minutes, and the GraphQL client also refreshes reactively on a 401,
+     * so this buffer only needs to absorb request latency and clock skew — not
+     * pre-empt the whole token lifetime (which would mean refreshing on nearly
+     * every call).
+     */
+    private const ACCESS_TOKEN_REFRESH_BUFFER_MINUTES = 2;
+
+    private ?ShopifyGraphQLClient $client = null;
+
+    public function __construct(
+        protected Shop $shop,
+        protected ShopifyApp $shopifyApp,
+    ) {}
+
+    /**
+     * Details about the shop itself (name, currency, plan, contact).
+     *
+     * @return array<string, mixed>
+     */
+    public function details(): array
+    {
+        $query = <<<'GRAPHQL'
+            query GetShopDetails {
+                shop {
+                    id
+                    name
+                    myshopifyDomain
+                    currencyCode
+                    plan {
+                        publicDisplayName
+                    }
+                    contactEmail
+                }
+            }
+            GRAPHQL;
+
+        return $this->graphql()->query($query)->data()['shop'] ?? [];
+    }
+
+    /**
+     * GraphQL client for this shop. Proactively refreshes the access token if
+     * it is near expiry, and the returned client will reactively refresh on a
+     * 401 from Shopify and retry once.
+     */
+    public function graphql(): ShopifyGraphQLClient
+    {
+        if ($this->client !== null) {
+            return $this->client;
+        }
+
+        if ($this->shouldAccessTokenBeRefreshed()) {
+            Log::debug('Proactively refreshing access token before issuing GraphQL client', [
+                'shop_id' => $this->shop->id,
+            ]);
+            app(RefreshAccessTokenAction::class)->execute($this->shop);
+        }
+
+        $accessToken = $this->shop->accessToken;
+
+        if (! $accessToken) {
+            throw new MissingAccessTokenException(shopDomain: $this->shop->getShopifySubdomain());
+        }
+
+        $apiVersion = config('shopify.api_version');
+
+        if (blank($apiVersion)) {
+            throw new MissingApiVersionException(shopDomain: $this->shop->getShopifySubdomain());
+        }
+
+        return $this->client = new ShopifyGraphQLClient(
+            shopifyApp: $this->shopifyApp,
+            shopDomain: $this->shop->getShopifySubdomain(),
+            accessToken: $accessToken->token,
+            apiVersion: $apiVersion,
+            refresher: function (): string {
+                app(RefreshAccessTokenAction::class)->execute($this->shop);
+
+                return $this->shop->accessToken->token;
+            },
+        );
+    }
+
+    /**
+     * Check if the shop has a valid (non-expired) access token.
+     */
+    public function isAccessTokenValid(): bool
+    {
+        $accessToken = $this->shop->accessToken;
+
+        if (! $accessToken) {
+            return false;
+        }
+
+        if (! $accessToken->expires_at) {
+            return true;
+        }
+
+        return $accessToken->expires_at->isFuture();
+    }
+
+    /**
+     * Check if the access token should be proactively refreshed.
+     *
+     * Returns true if the token is expiring soon (within the threshold)
+     * or if the refresh token is about to expire.
+     */
+    public function shouldAccessTokenBeRefreshed(int $thresholdMinutes = self::ACCESS_TOKEN_REFRESH_BUFFER_MINUTES): bool
+    {
+        $accessToken = $this->shop->accessToken;
+
+        if (! $accessToken) {
+            return false;
+        }
+
+        if (! $accessToken->expires_at) {
+            return false;
+        }
+
+        if ($accessToken->expires_at->isPast()) {
+            return true;
+        }
+
+        if (now()->diffInMinutes($accessToken->expires_at, absolute: true) <= $thresholdMinutes) {
+            return true;
+        }
+
+        if ($accessToken->refresh_token_expires_at && now()->diffInMinutes($accessToken->refresh_token_expires_at, absolute: true) <= $thresholdMinutes) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Refresh the shop's access token via the Shopify API.
+     *
+     * @throws MissingAccessTokenException
+     * @throws ShopifyAuthException
+     * @throws AccessTokenStillValidException
+     */
+    public function refreshAccessToken(): TokenExchangeAccessToken
+    {
+        $accessToken = $this->shop->accessToken;
+
+        if (! $accessToken) {
+            throw new MissingAccessTokenException(shopDomain: $this->shop->getShopifySubdomain());
+        }
+
+        Log::debug('Attempting to refresh Shopify access token', [
+            'shop_id' => $this->shop->id,
+            'access_token_id' => $accessToken->id,
+        ]);
+
+        // The shopify-app-php package appends `.myshopify.com` when building the
+        // OAuth token endpoint URL, so we must pass the subdomain only.
+        $refreshResult = $this->shopifyApp->refreshTokenExchangedAccessToken([
+            'accessMode' => 'offline',
+            'shop' => $this->shop->getShopifySubdomain(),
+            'token' => $accessToken->token,
+            'expires' => $accessToken->expires_at?->format('Y-m-d\TH:i:s\Z'),
+            'scope' => implode(',', $accessToken->scopes),
+            'refreshToken' => $accessToken->refresh_token,
+            'refreshTokenExpires' => $accessToken->refresh_token_expires_at?->format('Y-m-d\TH:i:s\Z'),
+            'user' => null,
+        ]);
+
+        if (! $refreshResult->ok) {
+            Log::error('Failed to refresh Shopify access token', [
+                'shop_id' => $this->shop->id,
+                'access_token_id' => $accessToken->id,
+                'log_code' => $refreshResult->log?->code,
+                'log_detail' => $refreshResult->log?->detail,
+                'response_status' => $refreshResult->response->status,
+                'response_body' => $refreshResult->response->body,
+            ]);
+
+            throw ShopifyAuthException::fromResult($refreshResult, $this->shop);
+        }
+
+        if (! $refreshResult->accessToken) {
+            Log::debug('Access token is still valid, no refresh needed', [
+                'shop_id' => $this->shop->id,
+                'access_token_id' => $accessToken->id,
+            ]);
+
+            throw new AccessTokenStillValidException;
+        }
+
+        Log::info('Successfully refreshed Shopify access token', [
+            'shop_id' => $this->shop->id,
+            'access_token_id' => $accessToken->id,
+        ]);
+
+        return $refreshResult->accessToken;
+    }
+}

--- a/web/app/Services/Shopify/ShopifyShopFactory.php
+++ b/web/app/Services/Shopify/ShopifyShopFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services\Shopify;
+
+use App\Models\Shop;
+use Shopify\App\ShopifyApp;
+
+class ShopifyShopFactory
+{
+    public function __construct(
+        protected ShopifyApp $shopifyApp,
+    ) {}
+
+    public function forShop(Shop $shop): ShopifyShop
+    {
+        return new ShopifyShop(
+            shop: $shop,
+            shopifyApp: $this->shopifyApp,
+        );
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/Handlers/AppUninstalledHandler.php
+++ b/web/app/Services/Shopify/Webhooks/Handlers/AppUninstalledHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks\Handlers;
+
+use App\Actions\DeleteAccessTokenAction;
+use App\Actions\MarkShopAsUninstalledAction;
+use App\Models\Shop;
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookHandler;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handles the app/uninstalled webhook.
+ *
+ * Deletes the persisted offline access token and marks the shop as
+ * uninstalled. The Shop row itself is kept until the shop/redact webhook
+ * arrives ~48 hours later.
+ */
+class AppUninstalledHandler implements WebhookHandler
+{
+    public function __construct(
+        protected DeleteAccessTokenAction $deleteAccessToken,
+        protected MarkShopAsUninstalledAction $markShopAsUninstalled,
+    ) {}
+
+    public function handle(ShopifyWebhook $webhook): void
+    {
+        $shop = Shop::query()->where('shop_domain', $webhook->shopDomain)->first();
+
+        if ($shop === null) {
+            Log::warning('Received app/uninstalled webhook for unknown shop', [
+                'shop_domain' => $webhook->shopDomain,
+                'webhook_id' => $webhook->webhookId,
+            ]);
+
+            return;
+        }
+
+        $this->deleteAccessToken->execute($shop);
+        $this->markShopAsUninstalled->execute($shop);
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/Handlers/CustomersDataRequestHandler.php
+++ b/web/app/Services/Shopify/Webhooks/Handlers/CustomersDataRequestHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks\Handlers;
+
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookHandler;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handles the customers/data_request GDPR compliance webhook.
+ *
+ * The app does not persist any customer data (orders are read on demand from
+ * the Shopify API and never stored), so there is no data to compile. The
+ * request is logged for the audit trail.
+ *
+ * @see https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance
+ */
+class CustomersDataRequestHandler implements WebhookHandler
+{
+    public function handle(ShopifyWebhook $webhook): void
+    {
+        Log::info('Received customers/data_request compliance webhook - no customer data is stored by this app', [
+            'shop_domain' => $webhook->shopDomain,
+            'webhook_id' => $webhook->webhookId,
+            'customer_id' => $webhook->payload['customer']['id'] ?? null,
+            'data_request_id' => $webhook->payload['data_request']['id'] ?? null,
+        ]);
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/Handlers/CustomersRedactHandler.php
+++ b/web/app/Services/Shopify/Webhooks/Handlers/CustomersRedactHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks\Handlers;
+
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookHandler;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handles the customers/redact GDPR compliance webhook.
+ *
+ * The app does not persist any customer data (orders are read on demand from
+ * the Shopify API and never stored), so there is nothing to redact. The
+ * request is logged for the audit trail.
+ *
+ * @see https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance
+ */
+class CustomersRedactHandler implements WebhookHandler
+{
+    public function handle(ShopifyWebhook $webhook): void
+    {
+        Log::info('Received customers/redact compliance webhook - no customer data is stored by this app', [
+            'shop_domain' => $webhook->shopDomain,
+            'webhook_id' => $webhook->webhookId,
+            'customer_id' => $webhook->payload['customer']['id'] ?? null,
+        ]);
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/Handlers/ShopRedactHandler.php
+++ b/web/app/Services/Shopify/Webhooks/Handlers/ShopRedactHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks\Handlers;
+
+use App\Models\Shop;
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookHandler;
+use App\Workflows\DeleteShopWorkflow;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handles the shop/redact GDPR compliance webhook.
+ *
+ * Sent ~48 hours after a shop uninstalls the app. Deletes the Shop row and
+ * any remaining access token so no shop data is retained.
+ *
+ * @see https://shopify.dev/docs/apps/build/compliance/privacy-law-compliance
+ */
+class ShopRedactHandler implements WebhookHandler
+{
+    public function __construct(protected DeleteShopWorkflow $deleteShop) {}
+
+    public function handle(ShopifyWebhook $webhook): void
+    {
+        $shop = Shop::query()->where('shop_domain', $webhook->shopDomain)->first();
+
+        if ($shop === null) {
+            Log::info('Received shop/redact compliance webhook for unknown shop - nothing to redact', [
+                'shop_domain' => $webhook->shopDomain,
+                'webhook_id' => $webhook->webhookId,
+            ]);
+
+            return;
+        }
+
+        $this->deleteShop->execute($shop);
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/ShopifyWebhook.php
+++ b/web/app/Services/Shopify/Webhooks/ShopifyWebhook.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks;
+
+use Illuminate\Http\Request;
+
+/**
+ * Immutable value object representing an incoming Shopify webhook request.
+ *
+ * Built from the standard Shopify webhook headers and the JSON payload.
+ *
+ * @see https://shopify.dev/docs/apps/build/webhooks
+ */
+readonly class ShopifyWebhook
+{
+    /**
+     * @param  string  $webhookId  Unique per delivery - used as the idempotency/deduplication key.
+     * @param  string  $eventId  Correlation id - the same merchant action can produce multiple deliveries with different webhook ids but the same event id.
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(
+        public string $topic,
+        public string $shopDomain,
+        public string $webhookId,
+        public string $eventId,
+        public string $apiVersion,
+        public array $payload,
+    ) {}
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            topic: (string) $request->header('X-Shopify-Topic'),
+            shopDomain: (string) $request->header('X-Shopify-Shop-Domain'),
+            webhookId: (string) $request->header('X-Shopify-Webhook-Id'),
+            eventId: (string) $request->header('X-Shopify-Event-Id'),
+            apiVersion: (string) $request->header('X-Shopify-API-Version'),
+            payload: $request->json()->all(),
+        );
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/WebhookDeduplicator.php
+++ b/web/app/Services/Shopify/Webhooks/WebhookDeduplicator.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks;
+
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Deduplicates Shopify webhook deliveries using the X-Shopify-Webhook-Id.
+ *
+ * Shopify may deliver the same webhook more than once (timeouts, retries).
+ * The claim is an atomic cache lock keyed on the webhook id with a 24-hour
+ * duration: the first delivery acquires the lock and keeps it - the held
+ * lock IS the deduplication record. It is never released on success and
+ * simply expires after 24 hours. Concurrent or repeated deliveries fail to
+ * acquire the lock and are skipped. Requires a cache store with atomic lock
+ * support (database, redis, file and array all qualify).
+ *
+ * DB-backed storage of processed webhooks was considered and deliberately
+ * deferred - this class is the single place to swap if that is ever needed.
+ *
+ * @see https://shopify.dev/docs/apps/build/webhooks/verify-deliveries#ignoring-duplicates
+ */
+class WebhookDeduplicator
+{
+    /**
+     * How long a claimed webhook id blocks duplicate deliveries.
+     */
+    protected const LOCK_SECONDS = 60 * 60 * 24;
+
+    /**
+     * Locks acquired by this instance, kept so release() can free the exact
+     * lock owner when a handler fails.
+     *
+     * @var array<string, Lock>
+     */
+    protected array $acquiredLocks = [];
+
+    /**
+     * Atomically claim a webhook delivery for processing.
+     *
+     * Returns true when this delivery is new (lock acquired now) and should
+     * be processed, false when the webhook id has been seen before (lock
+     * already held). Deliveries without a webhook id (e.g. `shopify app
+     * webhook trigger` from the CLI) cannot be deduplicated and are always
+     * claimed.
+     */
+    public function claim(ShopifyWebhook $webhook): bool
+    {
+        if ($webhook->webhookId === '') {
+            Log::warning('Shopify webhook delivered without X-Shopify-Webhook-Id header - skipping deduplication', [
+                'topic' => $webhook->topic,
+                'shop_domain' => $webhook->shopDomain,
+                'event_id' => $webhook->eventId,
+            ]);
+
+            return true;
+        }
+
+        $lock = Cache::lock($this->lockKey($webhook), self::LOCK_SECONDS);
+
+        if (! $lock->get()) {
+            return false;
+        }
+
+        // Deliberately NOT released on success: the held lock is the dedup
+        // record until it expires. Kept here so release() can free it if the
+        // handler throws.
+        $this->acquiredLocks[$webhook->webhookId] = $lock;
+
+        return true;
+    }
+
+    /**
+     * Release a previously claimed webhook delivery.
+     *
+     * Called when the handler throws so that Shopify's retry of the same
+     * webhook id is processed instead of being skipped as a duplicate.
+     */
+    public function release(ShopifyWebhook $webhook): void
+    {
+        $lock = $this->acquiredLocks[$webhook->webhookId] ?? null;
+
+        if ($lock === null) {
+            return;
+        }
+
+        $lock->release();
+        unset($this->acquiredLocks[$webhook->webhookId]);
+    }
+
+    protected function lockKey(ShopifyWebhook $webhook): string
+    {
+        return 'shopify-webhook:'.$webhook->webhookId;
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/WebhookDispatcher.php
+++ b/web/app/Services/Shopify/Webhooks/WebhookDispatcher.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks;
+
+use App\Services\Shopify\Webhooks\Handlers\AppUninstalledHandler;
+use App\Services\Shopify\Webhooks\Handlers\CustomersDataRequestHandler;
+use App\Services\Shopify\Webhooks\Handlers\CustomersRedactHandler;
+use App\Services\Shopify\Webhooks\Handlers\ShopRedactHandler;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Routes verified Shopify webhooks to their topic handler.
+ *
+ * All webhook topics are delivered to the single canonical endpoint
+ * /webhooks/shopify (see shopify.app.toml) and dispatched here based on the
+ * X-Shopify-Topic header. To support a new topic, implement
+ * {@see WebhookHandler} and add the topic to the $handlers map below.
+ *
+ * Duplicate deliveries (Shopify retries on timeouts) are detected centrally
+ * here via {@see WebhookDeduplicator}, so individual handlers never see the
+ * same webhook id twice and do not need their own idempotency logic.
+ */
+class WebhookDispatcher
+{
+    /**
+     * Map of Shopify webhook topic to handler class.
+     *
+     * @var array<string, class-string<WebhookHandler>>
+     */
+    protected array $handlers = [
+        'app/uninstalled' => AppUninstalledHandler::class,
+        'customers/data_request' => CustomersDataRequestHandler::class,
+        'customers/redact' => CustomersRedactHandler::class,
+        'shop/redact' => ShopRedactHandler::class,
+    ];
+
+    public function __construct(protected WebhookDeduplicator $deduplicator) {}
+
+    public function dispatch(ShopifyWebhook $webhook): void
+    {
+        $handlerClass = $this->handlers[$webhook->topic] ?? null;
+
+        if ($handlerClass === null) {
+            // Acknowledge with 200 anyway (handled by the controller) so
+            // Shopify does not retry a topic we have no handler for.
+            Log::warning('Received Shopify webhook with no registered handler', [
+                'topic' => $webhook->topic,
+                'shop_domain' => $webhook->shopDomain,
+                'webhook_id' => $webhook->webhookId,
+                'event_id' => $webhook->eventId,
+            ]);
+
+            return;
+        }
+
+        if (! $this->deduplicator->claim($webhook)) {
+            Log::info('Skipping duplicate Shopify webhook delivery - webhook id has already been processed', [
+                'webhook_id' => $webhook->webhookId,
+                'event_id' => $webhook->eventId,
+                'topic' => $webhook->topic,
+                'shop_domain' => $webhook->shopDomain,
+            ]);
+
+            return;
+        }
+
+        try {
+            app($handlerClass)->handle($webhook);
+        } catch (Throwable $exception) {
+            // Release the idempotency claim so Shopify's retry of this
+            // webhook id is processed instead of being skipped.
+            $this->deduplicator->release($webhook);
+
+            throw $exception;
+        }
+    }
+}

--- a/web/app/Services/Shopify/Webhooks/WebhookHandler.php
+++ b/web/app/Services/Shopify/Webhooks/WebhookHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services\Shopify\Webhooks;
+
+/**
+ * Contract for Shopify webhook topic handlers.
+ *
+ * Handlers run synchronously within the webhook request, which must complete
+ * within Shopify's 5-second timeout. Keep handlers fast and dispatch a queued
+ * job for any heavy lifting.
+ *
+ * Register implementations in {@see WebhookDispatcher::$handlers}.
+ */
+interface WebhookHandler
+{
+    public function handle(ShopifyWebhook $webhook): void;
+}

--- a/web/app/Workflows/DeleteShopWorkflow.php
+++ b/web/app/Workflows/DeleteShopWorkflow.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Workflows;
+
+use App\Actions\DeleteAccessTokenAction;
+use App\Models\Shop;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Deletes a shop and all data associated with it.
+ *
+ * Used to redact shop data (shop/redact compliance webhook), but reusable
+ * anywhere a shop must be removed entirely.
+ *
+ * This is a workflow (not an action) because it composes other actions:
+ * workflows may call actions, actions never call actions or workflows, and
+ * workflows never call other workflows.
+ */
+class DeleteShopWorkflow
+{
+    public function __construct(protected DeleteAccessTokenAction $deleteAccessToken) {}
+
+    public function execute(Shop $shop): void
+    {
+        $shopDomain = $shop->shop_domain;
+
+        $this->deleteAccessToken->execute($shop);
+        $shop->delete();
+
+        Log::info('Deleted shop and all associated data', [
+            'shop_domain' => $shopDomain,
+        ]);
+    }
+}

--- a/web/bootstrap/app.php
+++ b/web/bootstrap/app.php
@@ -1,18 +1,75 @@
 <?php
 
+use App\Http\Middleware\AssignRequestIdMiddleware;
+use App\Http\Middleware\ContentSecurityPolicyHeader;
+use App\Http\Middleware\VerifyShopifyAppHome;
+use App\Http\Middleware\VerifyShopifyWebhook;
+use Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            // Shopify webhooks: registered outside the web group (no session,
+            // no CSRF), protected by HMAC verification only.
+            Route::middleware(VerifyShopifyWebhook::class)
+                ->group(__DIR__.'/../routes/webhooks.php');
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->prepend(\App\Http\Middleware\ContentSecurityPolicyHeader::class);
+        // The app always runs behind a TLS-terminating proxy (cloudflare tunnel
+        // in dev, the platform load balancer in production) that forwards plain
+        // HTTP. Trusting the X-Forwarded-* headers makes Laravel see the real
+        // https scheme — otherwise generated URLs (including asset URLs) come
+        // out as http://, and the browser's mixed-content auto-upgrade reloads
+        // assets under a second URL.
+        $middleware->trustProxies(at: '*');
+
+        $middleware->prepend(ContentSecurityPolicyHeader::class);
+
+        // Tag every request (and its log lines) with a request id the merchant
+        // can quote to support. Prepended last so it runs first — before anything
+        // that might fail. See App\Http\Middleware\AssignRequestIdMiddleware.
+        $middleware->prepend(AssignRequestIdMiddleware::class);
+
+        // Shopify verification must run before the `auth:apphome` guard resolves,
+        // so a recoverable failure returns the package's own response (302 patch
+        // redirect / 401 retry) instead of the framework's generic 401. Laravel's
+        // middleware priority otherwise floats Authenticate ahead of an
+        // unprioritised route middleware, so pin our order explicitly.
+        $middleware->prependToPriorityList(
+            before: AuthenticatesRequests::class,
+            prepend: VerifyShopifyAppHome::class,
+        );
+
+        // Embedded Shopify apps have no `login` route: real traffic always
+        // arrives inside the Admin iframe with a valid id_token. Returning null
+        // here makes the framework respond with a plain 401 instead of trying
+        // to redirect to a non-existent named route.
+        $middleware->redirectGuestsTo(fn () => null);
+
+        // The embedded app runs inside the Shopify Admin iframe, where the
+        // session cookie is third-party and routinely blocked by the browser.
+        // Every request therefore starts a fresh session, so the CSRF token can
+        // never match and POST/PATCH/DELETE requests fail with 419. Those routes
+        // are not cookie-authenticated — the `auth:apphome` guard verifies a
+        // Shopify session token in the Authorization header, which a cross-site
+        // attacker cannot forge — so CSRF protection is both unnecessary and
+        // broken here. List your embedded app's mutating routes below to exempt
+        // them, e.g. 'settings', 'settings/*'.
+        $middleware->validateCsrfTokens(except: [
+            //
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Errors render through Laravel's Blade error views in
+        // resources/views/errors/. The bundled errors/500.blade.php surfaces the
+        // request id (App\Http\Middleware\AssignRequestIdMiddleware) so merchants
+        // can quote it to support.
     })->create();

--- a/web/composer.json
+++ b/web/composer.json
@@ -9,9 +9,10 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.5",
         "laravel/framework": "^13.8",
-        "laravel/tinker": "^3.0"
+        "laravel/tinker": "^3.0",
+        "shopify/shopify-app-php": "^0.1.4"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad874bdf2dc08c4892f8a96cdea87203",
+    "content-hash": "4ec13a6a8484613a102478afa866cada",
     "packages": [
         {
             "name": "brick/math",
@@ -509,6 +509,72 @@
             "time": "2025-03-06T22:45:56+00:00"
         },
         {
+            "name": "firebase/php-jwt",
+            "version": "v7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/googleapis/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
+            },
+            "time": "2026-06-11T17:54:14+00:00"
+        },
+        {
             "name": "fruitcake/php-cors",
             "version": "v1.4.0",
             "source": {
@@ -643,25 +709,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
+                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -670,8 +737,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -749,7 +817,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.3"
             },
             "funding": [
                 {
@@ -765,28 +833,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-23T15:29:02+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -832,7 +901,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -848,27 +917,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -876,9 +947,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -949,7 +1020,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -965,7 +1036,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -3299,6 +3370,61 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "shopify/shopify-app-php",
+            "version": "v0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Shopify/shopify-app-php.git",
+                "reference": "b9c49ce62066a1b621332c21dc82f3810a804058"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Shopify/shopify-app-php/zipball/b9c49ce62066a1b621332c21dc82f3810a804058",
+                "reference": "b9c49ce62066a1b621332c21dc82f3810a804058",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^7.0",
+                "guzzlehttp/guzzle": "^7.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Version.php"
+                ],
+                "psr-4": {
+                    "Shopify\\App\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Package for building Shopify apps. Authored and maintained by Shopify.",
+            "homepage": "https://packagist.org/packages/shopify/shopify-app-php",
+            "keywords": [
+                "admin-graphql",
+                "app-proxy",
+                "client-credentials",
+                "flow-action",
+                "shopify",
+                "shopify-apps",
+                "token-exchange",
+                "webhooks"
+            ],
+            "support": {
+                "changelog": "https://github.com/Shopify/shopify-app-php/blob/main/CHANGELOG.md",
+                "forum": "https://community.shopify.dev/c/shopify-cli-libraries/14",
+                "issues": "https://community.shopify.dev/c/shopify-cli-libraries/14",
+                "source": "https://github.com/Shopify/shopify-app-php/tree/v0.1.4"
+            },
+            "time": "2026-03-19T13:59:46+00:00"
         },
         {
             "name": "symfony/clock",
@@ -9470,7 +9596,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/web/config/auth.php
+++ b/web/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Auth\Guards\ShopifyAppHomeGuard;
+use App\Models\Shop;
 use App\Models\User;
 
 return [
@@ -42,6 +44,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'apphome' => [
+            'driver' => ShopifyAppHomeGuard::DRIVER_NAME,
+            'provider' => 'shops',
+        ],
     ],
 
     /*
@@ -65,6 +72,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', User::class),
+        ],
+
+        'shops' => [
+            'driver' => 'eloquent',
+            'model' => Shop::class,
         ],
 
         // 'users' => [

--- a/web/config/shopify.php
+++ b/web/config/shopify.php
@@ -4,6 +4,25 @@ return [
 
     'client_id' => env('SHOPIFY_CLIENT_ID'),
 
+    'client_secret' => env('SHOPIFY_CLIENT_SECRET'),
+
+    /*
+     * The Admin API version goes straight into the request URL
+     * (`/admin/api/{version}/graphql.json`). Valid values are date versions
+     * (e.g. `2025-01`) or `unstable`; there is no `latest` token — an
+     * unrecognized value makes Shopify silently fall *forward* to the oldest
+     * accessible stable version.
+     *
+     * Unset falls back to the default below (the newest version this app is
+     * built and tested against). An explicit-but-empty SHOPIFY_API_VERSION is
+     * deliberately left as an empty string so it is rejected loudly when a
+     * GraphQL client is built — see ShopifyShop::graphql() and
+     * MissingApiVersionException — rather than masking a misconfiguration.
+     */
+    'api_version' => env('SHOPIFY_API_VERSION', '2026-01'),
+
+    'patch_id_token_path' => '/auth/patch-id-token',
+
     /*
     |--------------------------------------------------------------------------
     | Shopify App Bridge

--- a/web/database/factories/AccessTokenFactory.php
+++ b/web/database/factories/AccessTokenFactory.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AccessTokenMode;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AccessToken>
+ */
+class AccessTokenFactory extends Factory
+{
+    protected $model = AccessToken::class;
+
+    /**
+     * Valid Shopify Access Scopes for generating realistic test data.
+     *
+     * @var array<string>
+     *
+     * @see https://shopify.dev/docs/api/usage/access-scopes
+     */
+    private const SHOPIFY_SCOPES = [
+        // **Authenticated access scopes**
+        'read_all_orders',
+        'write_app_proxy',
+        'read_assigned_fulfillment_orders',
+        'write_assigned_fulfillment_orders',
+        'read_merchant_managed_fulfillment_orders',
+        'write_merchant_managed_fulfillment_orders',
+        'read_third_party_fulfillment_orders',
+        'write_third_party_fulfillment_orders',
+        'read_marketplace_fulfillment_orders',
+        'read_cart_transforms',
+        'write_cart_transforms',
+        'read_checkout_branding_settings',
+        'write_checkout_branding_settings',
+        'read_content',
+        'write_content',
+        'read_online_store_pages',
+        'read_customer_events',
+        'write_pixels',
+        'read_customer_merge',
+        'write_customer_merge',
+        'read_customer_payment_methods',
+        'read_customers',
+        'write_customers',
+        'read_delivery_customizations',
+        'write_delivery_customizations',
+        'read_discounts',
+        'write_discounts',
+        'read_draft_orders',
+        'write_draft_orders',
+        'read_files',
+        'write_files',
+        'read_fulfillments',
+        'write_fulfillments',
+        'read_gift_cards',
+        'write_gift_cards',
+        'read_inventory',
+        'write_inventory',
+        'read_legal_policies',
+        'read_locales',
+        'write_locales',
+        'read_locations',
+        'write_locations',
+        'read_markets',
+        'write_markets',
+        'read_marketing_events',
+        'write_marketing_events',
+        'read_merchant_approval_signals',
+        'read_metaobject_definitions',
+        'write_metaobject_definitions',
+        'read_metaobjects',
+        'write_metaobjects',
+        'read_online_store_navigation',
+        'write_online_store_navigation',
+        'read_order_edits',
+        'write_order_edits',
+        'read_orders',
+        'write_orders',
+        'read_own_subscription_contracts',
+        'write_own_subscription_contracts',
+        'read_payment_customizations',
+        'write_payment_customizations',
+        'read_payment_gateways',
+        'write_payment_gateways',
+        'read_payment_mandate',
+        'write_payment_mandate',
+        'write_payment_sessions',
+        'read_payment_terms',
+        'write_payment_terms',
+        'read_price_rules',
+        'write_price_rules',
+        'write_privacy_settings',
+        'read_privacy_settings',
+        'read_products',
+        'write_products',
+        'read_purchase_options',
+        'write_purchase_options',
+        'read_reports',
+        'read_returns',
+        'write_returns',
+        'read_script_tags',
+        'write_script_tags',
+        'read_shipping',
+        'write_shipping',
+        'read_shopify_payments_disputes',
+        'read_shopify_payments_dispute_evidences',
+        'read_shopify_payments_payouts',
+        'read_store_credit_accounts',
+        'read_store_credit_account_transactions',
+        'read_store_credit_account_transactions',
+        'read_themes',
+        'write_themes',
+        'read_translations',
+        'read_users',
+        'read_validations',
+        'write_validations',
+        // *Unauthenticated access scopes*
+        // Provide apps with read-only access to the Storefront API. Unauthenticated access
+        // is intended for interacting with a store on behalf of a customer.
+        // 'unauthenticated_read_checkouts'
+        // 'unauthenticated_write_checkouts'
+        // 'unauthenticated_read_customers'
+        // 'unauthenticated_write_customers'
+        // 'unauthenticated_read_customer_tags'
+        // 'unauthenticated_read_content'
+        // 'unauthenticated_read_metaobjects'
+        // 'unauthenticated_read_product_inventory'
+        // 'unauthenticated_read_product_listings'
+        // 'unauthenticated_read_product_pickup_locations'
+        // 'unauthenticated_read_product_tags'
+        // 'unauthenticated_read_selling_plans'
+        // *Customer access scopes*
+        // Provide apps with read and write access to the Customer Account API. Customer access
+        // is intended for interacting with data that belongs to a customer.
+        // 'customer_read_customers'
+        // 'customer_write_customers'
+        // 'customer_read_orders'
+        // 'customer_write_orders'
+        // 'customer_read_draft_orders'
+        // 'customer_read_markets'
+        // 'customer_read_metaobjects'
+        // 'customer_read_store_credit_accounts'
+        // 'customer_read_own_subscription_contracts'
+        // 'customer_write_own_subscription_contracts'
+        // 'customer_write_subscription_contracts'
+        // 'customer_read_companies'
+        // 'customer_write_companies'
+        // 'customer_read_locations'
+        // 'customer_write_locations'
+    ];
+
+    /**
+     * Default: non-expiring offline access token.
+     */
+    public function definition(): array
+    {
+        return [
+            'shop_id' => Shop::factory(),
+            'token' => 'shpat_'.fake()->bothify(str_repeat('*', 32)), // Prefixed with shpat_ (for public apps), shpca_ (for custom apps), or shppa_ (for legacy private apps)
+            'mode' => AccessTokenMode::Offline,
+            'scopes' => fake()->randomElements(self::SHOPIFY_SCOPES, fake()->numberBetween(3, 6)),
+        ];
+    }
+
+    public function offlineNonExpiring(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => null,
+            'refresh_token' => null,
+            'refresh_token_expires_at' => null,
+        ]);
+    }
+
+    public function offline(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => fake()->dateTimeBetween('+1 hour', '+90 days'),
+            'refresh_token' => 'shprt_'.fake()->bothify(str_repeat('*', 32)),
+            'refresh_token_expires_at' => fake()->dateTimeBetween('+1 day', '+1 year'),
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'expires_at' => fake()->dateTime('now'),
+        ]);
+    }
+
+    public function expiredRefreshToken(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'refresh_token_expires_at' => fake()->dateTime('now'),
+        ]);
+    }
+}

--- a/web/database/factories/ShopFactory.php
+++ b/web/database/factories/ShopFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Shop>
+ */
+class ShopFactory extends Factory
+{
+    protected $model = Shop::class;
+
+    public function definition(): array
+    {
+        return [
+            'shop_domain' => fake()->unique()->domainWord().'.myshopify.com',
+            'name' => fake()->slug(4),
+            'email' => fake()->companyEmail(),
+        ];
+    }
+}

--- a/web/database/migrations/2026_01_13_210956_create_shops_table.php
+++ b/web/database/migrations/2026_01_13_210956_create_shops_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shops', function (Blueprint $table) {
+            $table->id();
+            $table->string('shop_domain')->unique(); // e.g., "mystore.myshopify.com"
+            $table->string('name')->nullable(); // Shop name eg 'Awesome Hat Store'
+            $table->string('email')->nullable(); // Shop owner email eg 'owner@hatstore.com'
+            $table->timestamps();
+
+            $table->index('shop_domain');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shops');
+    }
+};

--- a/web/database/migrations/2026_01_27_231524_create_access_tokens_table.php
+++ b/web/database/migrations/2026_01_27_231524_create_access_tokens_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('shop_id')->unique();
+            $table->string('token');
+            $table->string('mode'); // 'online' or 'offline'
+            $table->json('scopes');
+            $table->timestamp('expires_at')->nullable();
+            $table->string('refresh_token')->nullable();
+            $table->timestamp('refresh_token_expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('access_tokens');
+    }
+};

--- a/web/database/migrations/2026_06_10_113945_add_uninstalled_at_to_shops_table.php
+++ b/web/database/migrations/2026_06_10_113945_add_uninstalled_at_to_shops_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('shops', function (Blueprint $table) {
+            $table->timestamp('uninstalled_at')->nullable()->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('shops', function (Blueprint $table) {
+            $table->dropColumn('uninstalled_at');
+        });
+    }
+};

--- a/web/phpunit.xml
+++ b/web/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
+         defaultTestSuite="Unit,Feature"
 >
     <testsuites>
         <testsuite name="Unit">
@@ -10,6 +11,9 @@
         </testsuite>
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Contract">
+            <directory>tests/Contract</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/web/resources/views/errors/500.blade.php
+++ b/web/resources/views/errors/500.blade.php
@@ -1,0 +1,47 @@
+@php
+    // The request id shown here also tags every log line for this request.
+    // See App\Http\Middleware\AssignRequestIdMiddleware.
+    $reference = \Illuminate\Support\Facades\Context::get(\App\Http\Middleware\AssignRequestIdMiddleware::CONTEXT_KEY);
+@endphp
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Something went wrong</title>
+        <style>
+            body {
+                margin: 0;
+                min-height: 100vh;
+                display: grid;
+                place-items: center;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                color: #202223;
+                background: #f6f6f7;
+            }
+            .card {
+                max-width: 28rem;
+                margin: 1.5rem;
+                padding: 2rem;
+                text-align: center;
+            }
+            h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+            p { margin: 0 0 1rem; line-height: 1.5; color: #6d7175; }
+            code {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-size: 0.8125rem;
+                background: rgba(0, 0, 0, 0.06);
+                padding: 0.15rem 0.4rem;
+                border-radius: 0.375rem;
+                word-break: break-all;
+            }
+        </style>
+    </head>
+    <body>
+        <main class="card">
+            <h1>Something went wrong</h1>
+            <p>The app hit an unexpected error. Please try again shortly.</p>
+            <p>If the problem persists, contact support and quote reference<br /><code>{{ $reference }}</code></p>
+        </main>
+    </body>
+</html>

--- a/web/routes/web.php
+++ b/web/routes/web.php
@@ -1,7 +1,33 @@
 <?php
 
+use App\Http\Controllers\Auth\PatchIdTokenController;
+use App\Http\Middleware\VerifyShopifyAppHome;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('home');
+/*
+|--------------------------------------------------------------------------
+| Shopify Authentication Routes
+|--------------------------------------------------------------------------
+|
+| The patch-id-token route must be publicly accessible (no auth middleware):
+| App Bridge redirects here to recover a fresh session token. See
+| App\Http\Controllers\Auth\PatchIdTokenController.
+|
+*/
+
+Route::get('/auth/patch-id-token', PatchIdTokenController::class)->name('auth.patch-id-token');
+
+/*
+|--------------------------------------------------------------------------
+| App Home routes
+|--------------------------------------------------------------------------
+|
+| Routes rendered inside the Shopify Admin iframe. VerifyShopifyAppHome
+| verifies the Shopify session token and the `auth:apphome` guard resolves
+| the authenticated Shop. Add your embedded app pages inside this group.
+|
+*/
+
+Route::middleware([VerifyShopifyAppHome::class, 'auth:apphome'])->group(function () {
+    Route::view('/', 'home')->name('home');
 });

--- a/web/routes/webhooks.php
+++ b/web/routes/webhooks.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Http\Controllers\Shopify\Webhooks\WebhookController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Shopify Webhook Routes
+|--------------------------------------------------------------------------
+|
+| Single canonical endpoint receiving all Shopify webhook topics declared in
+| shopify.app.toml (app/uninstalled and the GDPR compliance topics). These
+| routes are registered without the web/api middleware groups (no session,
+| no CSRF) and are protected by the VerifyShopifyWebhook HMAC middleware
+| applied in bootstrap/app.php.
+|
+*/
+
+Route::post('/webhooks/shopify', WebhookController::class)->name('webhooks.shopify');

--- a/web/shopify.web.toml
+++ b/web/shopify.web.toml
@@ -1,6 +1,6 @@
 name = "laravel"
 roles = ["frontend", "backend"]
-webhooks_path = "/webhooks/app/uninstalled"
+webhooks_path = "/webhooks/shopify"
 
 port=8000 # Shopify assigns a random port if not specified, but there is no way to let PHP serve with the random port
 

--- a/web/tests/Contract/AuthContractTest.php
+++ b/web/tests/Contract/AuthContractTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Contract: with valid offline-token credentials for the test store, the
+ * GraphQL client can reach Shopify and authenticate.
+ *
+ * Failure mode this catches: token exchange semantics changed, our auth
+ * headers stopped working, the persisted token shape no longer matches what
+ * Shopify expects.
+ */
+beforeEach(function () {
+    if (! contractShopAvailable()) {
+        $this->markTestSkipped('No dev store install found — run `npm run dev` once to install the app (or set the TEST_STORE_* env vars in CI).');
+    }
+});
+
+it('authenticates against the real dev store', function () {
+    $shop = contractShop();
+
+    // Simplest authenticated read — if this succeeds, auth + transport + token shape all work.
+    $details = $shop->shopify()->details();
+
+    expect($details)->toBeArray()
+        ->and($details['myshopifyDomain'] ?? null)->toBe($shop->shop_domain);
+});

--- a/web/tests/Contract/ShopDetailsContractTest.php
+++ b/web/tests/Contract/ShopDetailsContractTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Contract: $shop->shopify()->details() returns the shape our app assumes.
+ *
+ * Failure mode this catches: Shopify renamed/removed a field on the `shop`
+ * root query, or changed the structure of `plan`.
+ */
+beforeEach(function () {
+    if (! contractShopAvailable()) {
+        $this->markTestSkipped('No dev store install found — run `npm run dev` once to install the app (or set the TEST_STORE_* env vars in CI).');
+    }
+});
+
+it('returns the documented shop details shape', function () {
+    $details = contractShop()->shopify()->details();
+
+    expect($details)
+        ->toHaveKeys(['id', 'name', 'myshopifyDomain', 'currencyCode', 'plan', 'contactEmail'])
+        ->and($details['id'])->toStartWith('gid://shopify/Shop/')
+        ->and($details['plan'])->toHaveKey('publicDisplayName');
+});

--- a/web/tests/Feature/Auth/PatchIdTokenControllerTest.php
+++ b/web/tests/Feature/Auth/PatchIdTokenControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Shopify\App\ShopifyApp;
+
+pest()->group('auth', 'controllers');
+
+beforeEach(function () {
+    config([
+        'shopify.client_id' => 'test-client-id',
+        'shopify.client_secret' => 'test-client-secret',
+    ]);
+});
+
+it('returns the app bridge html when request is valid', function () {
+    $response = $this->get('/auth/patch-id-token?shop=test-shop.myshopify.com&shopify-reload=/some/path');
+
+    $response->assertOk()
+        ->assertSee('<script data-api-key="test-client-id" src="https://cdn.shopify.com/shopifycloud/app-bridge.js"></script>', escape: false);
+
+    expect($response->headers->get('Content-Type'))->toContain('text/html');
+});
+
+it('returns correct Content-Security-Policy header', function () {
+    $response = $this->get('/auth/patch-id-token?shop=my-shop.myshopify.com&shopify-reload=/reload');
+
+    $response->assertOk()
+        ->assertHeader('Content-Security-Policy', 'frame-ancestors https://my-shop.myshopify.com https://admin.shopify.com;');
+});
+
+it('returns Link header for preloading app bridge', function () {
+    $response = $this->get('/auth/patch-id-token?shop=test.myshopify.com&shopify-reload=/path');
+
+    $response->assertOk()
+        ->assertHeader('Link', '<https://cdn.shopify.com/shopifycloud/app-bridge.js>; rel="preload"; as="script";');
+});
+
+it('returns 400 when shop parameter is missing', function () {
+    $response = $this->get('/auth/patch-id-token?shopify-reload=/path');
+
+    $response->assertBadRequest();
+});
+
+it('returns 400 when shopify-reload parameter is missing', function () {
+    $response = $this->get('/auth/patch-id-token?shop=test.myshopify.com');
+
+    $response->assertBadRequest();
+});
+
+it('returns 400 when both parameters are missing', function () {
+    $response = $this->get('/auth/patch-id-token');
+
+    $response->assertBadRequest();
+});
+
+it('returns 500 when client_id is not configured', function () {
+    config(['shopify.client_id' => null]);
+
+    // Need to clear the singleton to pick up new config
+    app()->forgetInstance(ShopifyApp::class);
+
+    $response = $this->get('/auth/patch-id-token?shop=test.myshopify.com&shopify-reload=/path');
+
+    $response->assertInternalServerError();
+});
+
+it('uses the correct route name', function () {
+    expect(route('auth.patch-id-token'))->toEndWith('/auth/patch-id-token');
+});

--- a/web/tests/Feature/Auth/ShopifyIdTokenTest.php
+++ b/web/tests/Feature/Auth/ShopifyIdTokenTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\AppHomePatchIdTokenResult;
+use Shopify\App\Types\LogWithReq;
+use Shopify\App\Types\ResponseInfo;
+
+describe('Patch Id Token', function () {
+    it('route exists by name', function () {
+        $route = route('auth.patch-id-token', absolute: false);
+
+        expect($route)->toBe('/auth/patch-id-token');
+    });
+
+    it('fetches a fresh token', function () {
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('appHomePatchIdToken')
+            ->once()
+            ->withArgs(function ($req) {
+                // Verify the request format matches what ShopifyApp expects
+                return isset($req['method'])
+                    && isset($req['headers'])
+                    && isset($req['url'])
+                    && isset($req['body'])
+                    && $req['method'] === 'GET'
+                    && str_contains($req['url'], '/auth/patch-id-token');
+            })
+            ->andReturn(new AppHomePatchIdTokenResult(
+                ok: true,
+                shop: 'test-shop',
+                log: new LogWithReq(
+                    code: 'success',
+                    detail: 'ID token patched successfully',
+                    req: []
+                ),
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '{"patched": true}',
+                    headers: ['Content-Type' => 'application/json']
+                )
+            ));
+
+        $this->app->instance(ShopifyApp::class, $mockShopify);
+
+        $response = $this->get('/auth/patch-id-token');
+
+        $response
+            ->assertStatus(200)
+            ->assertJson(['patched' => true]);
+    });
+
+    it('handles invalid token response', function () {
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('appHomePatchIdToken')
+            ->once()
+            ->andReturn(new AppHomePatchIdTokenResult(
+                ok: false,
+                shop: null,
+                log: new LogWithReq(
+                    code: 'invalid_token',
+                    detail: 'The ID token is invalid',
+                    req: []
+                ),
+                response: new ResponseInfo(
+                    status: 401,
+                    body: 'Invalid token',
+                    headers: []
+                )
+            ));
+
+        $this->app->instance(ShopifyApp::class, $mockShopify);
+
+        $response = $this->get('/auth/patch-id-token');
+
+        $response
+            ->assertStatus(401)
+            ->assertContent('Invalid token');
+    });
+});

--- a/web/tests/Feature/Auth/UnauthenticatedAccessTest.php
+++ b/web/tests/Feature/Auth/UnauthenticatedAccessTest.php
@@ -1,0 +1,23 @@
+<?php
+
+pest()->group('auth', 'middleware');
+
+it('redirects an unauthenticated embedded load to the patch-id-token page', function () {
+    // With no id_token on the request, the Shopify-recommended flow returns the
+    // package's own 302 to the patch-id-token page (App Bridge then fetches a
+    // fresh token and reloads) — not a redirect to a non-existent `login` route
+    // and not a generic 401. VerifyShopifyAppHome emits this before the
+    // auth:apphome guard's `redirectGuestsTo(null)` 401 fallback can run.
+    $this->get('/')
+        ->assertStatus(302)
+        ->assertRedirectContains('/auth/patch-id-token');
+});
+
+it('does not throw a RouteNotFoundException for a JSON request either', function () {
+    // Same path for a request that asks for JSON: no Authorization header means
+    // the package treats it as a document load and returns the patch redirect,
+    // never attempting the missing `login` route.
+    $this->getJson('/')
+        ->assertStatus(302)
+        ->assertRedirectContains('/auth/patch-id-token');
+});

--- a/web/tests/Feature/Auth/VerifyShopifyAppHomeTest.php
+++ b/web/tests/Feature/Auth/VerifyShopifyAppHomeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Services\Shopify\Exceptions\ShopifyCredentialMismatchException;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\LogWithReq;
+use Shopify\App\Types\ResponseInfo;
+use Shopify\App\Types\ResultWithExchangeableIdToken;
+
+/**
+ * The middleware must follow Shopify's recommended flow: on a recoverable
+ * verification failure it returns the package's own response (so App Bridge can
+ * refresh the session token) instead of a generic 401, while a genuine
+ * credential misconfiguration throws and is reported as a 500.
+ */
+function mockVerifyAppHomeReq(string $code, int $status, array $headers = [], string $body = ''): void
+{
+    $mockShopify = Mockery::mock(ShopifyApp::class);
+    $mockShopify->shouldReceive('verifyAppHomeReq')
+        ->once()
+        ->andReturn(new ResultWithExchangeableIdToken(
+            ok: false,
+            shop: null,
+            idToken: null,
+            userId: null,
+            newIdTokenResponse: null,
+            log: new LogWithReq(code: $code, detail: $code, req: []),
+            response: new ResponseInfo(status: $status, body: $body, headers: $headers),
+        ));
+
+    app()->instance(ShopifyApp::class, $mockShopify);
+}
+
+function unexpiredIdToken(): string
+{
+    $segment = fn (array $data) => rtrim(strtr(base64_encode(json_encode($data)), '+/', '-_'), '=');
+
+    return $segment(['alg' => 'HS256', 'typ' => 'JWT']).'.'.$segment(['exp' => time() + 300]).'.'.$segment(['sig']);
+}
+
+it('emits the package 302 patch-id-token redirect on a recoverable failure', function () {
+    mockVerifyAppHomeReq(
+        code: 'redirect_to_patch_id_token_page',
+        status: 302,
+        headers: ['Location' => 'https://example.test/auth/patch-id-token?shopify-reload=%2Fconnect'],
+    );
+
+    $this->get('/')
+        ->assertStatus(302)
+        ->assertHeader('Location', 'https://example.test/auth/patch-id-token?shopify-reload=%2Fconnect');
+});
+
+it('emits the package 401 retry response for a stale session token', function () {
+    // No id_token on the request → recoverable: the package response (a 401 with
+    // the retry header) is returned so App Bridge fetches a fresh token.
+    mockVerifyAppHomeReq(
+        code: 'invalid_id_token',
+        status: 401,
+        headers: ['X-Shopify-Retry-Invalid-Session-Request' => '1'],
+        body: 'Unauthorized',
+    );
+
+    $this->get('/')
+        ->assertStatus(401)
+        ->assertHeader('X-Shopify-Retry-Invalid-Session-Request', '1');
+});
+
+it('throws a reported credential mismatch on invalid_aud', function () {
+    $this->withoutExceptionHandling();
+
+    mockVerifyAppHomeReq(code: 'invalid_aud', status: 401);
+
+    expect(fn () => $this->get('/'))
+        ->toThrow(ShopifyCredentialMismatchException::class);
+});
+
+it('throws a reported credential mismatch when an unexpired document token is rejected', function () {
+    $this->withoutExceptionHandling();
+
+    mockVerifyAppHomeReq(code: 'redirect_to_patch_id_token_page', status: 302);
+
+    expect(fn () => $this->get('/?id_token='.unexpiredIdToken()))
+        ->toThrow(ShopifyCredentialMismatchException::class);
+});
+
+it('renders a generic 500 with a reference for a misconfiguration in production', function () {
+    config(['app.debug' => false]);
+
+    mockVerifyAppHomeReq(code: 'invalid_aud', status: 401);
+
+    $this->get('/')
+        ->assertStatus(500)
+        ->assertSee('Something went wrong')
+        ->assertDontSee('invalid_aud');
+});

--- a/web/tests/Feature/Console/Commands/Shopify/StoreDetailsCommandTest.php
+++ b/web/tests/Feature/Console/Commands/Shopify/StoreDetailsCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\AccessToken;
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\GQLResult;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+
+uses(RefreshDatabase::class);
+
+pest()->group('commands', 'shopify');
+
+it('displays store details when --shop is provided', function () {
+    $shop = Shop::factory()->create(['shop_domain' => 'test-store.myshopify.com']);
+    AccessToken::factory()->for($shop)->create();
+
+    $mockShopify = Mockery::mock(ShopifyApp::class);
+    $mockShopify->shouldReceive('adminGraphQLRequest')->once()->andReturn(new GQLResult(
+        ok: true,
+        shop: 'test-store',
+        data: [
+            'shop' => [
+                'id' => 'gid://shopify/Shop/1',
+                'name' => 'Test Store',
+                'myshopifyDomain' => 'test-store.myshopify.com',
+                'currencyCode' => 'USD',
+                'plan' => ['publicDisplayName' => 'Basic'],
+                'contactEmail' => 'owner@test.com',
+            ],
+        ],
+        extensions: null,
+        log: new Log(code: 'success', detail: 'OK'),
+        httpLogs: [],
+        response: new ResponseInfo(status: 200, body: '', headers: (object) []),
+    ));
+
+    $this->app->instance(ShopifyApp::class, $mockShopify);
+
+    $this->artisan('shopify:store-details', ['--shop' => 'test-store.myshopify.com'])
+        ->assertSuccessful();
+});
+
+it('fails when --shop is provided but not found', function () {
+    $this->artisan('shopify:store-details', ['--shop' => 'nonexistent.myshopify.com']);
+})->throws(ModelNotFoundException::class, 'Shop not found: nonexistent.myshopify.com');

--- a/web/tests/Feature/ExampleTest.php
+++ b/web/tests/Feature/ExampleTest.php
@@ -1,7 +1,0 @@
-<?php
-
-test('the application returns a successful response', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});

--- a/web/tests/Feature/Models/AccessTokenTest.php
+++ b/web/tests/Feature/Models/AccessTokenTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Enums\AccessTokenMode;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+pest()->group('models', 'access-token');
+
+it('can be created using the factory', function () {
+    $accessToken = AccessToken::factory()->create();
+
+    expect($accessToken)->toBeInstanceOf(AccessToken::class)
+        ->and($accessToken->id)->toBeInt()
+        ->and($accessToken->token)->toStartWith('shpat_')
+        ->and($accessToken->mode)->toBe(AccessTokenMode::Offline)
+        ->and($accessToken->scopes)->toBeArray()
+        ->and($accessToken->expires_at)->toBeNull()
+        ->and($accessToken->refresh_token)->toBeNull();
+});
+
+it('can be created as an expiring token', function () {
+    $accessToken = AccessToken::factory()->offline()->create();
+
+    expect($accessToken->expires_at)->not->toBeNull()
+        ->and($accessToken->refresh_token)->toStartWith('shprt_')
+        ->and($accessToken->refresh_token_expires_at)->not->toBeNull();
+});
+
+it('hides token and refresh_token when serialized', function () {
+    $accessToken = AccessToken::factory()->offline()->create();
+
+    $serialized = $accessToken->toArray();
+
+    expect($serialized)->not->toHaveKey('token')
+        ->and($serialized)->not->toHaveKey('refresh_token');
+});
+
+describe('casts', function () {
+    it('casts mode to AccessTokenMode enum', function () {
+        $accessToken = AccessToken::factory()->create(['mode' => 'offline']);
+
+        expect($accessToken->mode)->toBeInstanceOf(AccessTokenMode::class)
+            ->and($accessToken->mode)->toBe(AccessTokenMode::Offline);
+    });
+
+    it('casts scopes to an array', function () {
+        $scopes = ['read_products', 'write_orders'];
+
+        $accessToken = AccessToken::factory()->create(['scopes' => $scopes]);
+
+        expect($accessToken->scopes)->toBe($scopes)
+            ->and($accessToken->scopes)->toBeArray();
+    });
+
+    it('casts expires_at to a datetime', function () {
+        $accessToken = AccessToken::factory()->offline()->create();
+
+        expect($accessToken->expires_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
+
+    it('casts refresh_token_expires_at to a datetime', function () {
+        $accessToken = AccessToken::factory()->offline()->create();
+
+        expect($accessToken->refresh_token_expires_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
+})->group('casts');
+
+it('allows nullable attributes to be null', function (string $attribute) {
+    $accessToken = AccessToken::factory()->create([$attribute => null]);
+    $accessToken->refresh();
+
+    expect($accessToken->{$attribute})->toBeNull();
+})->with([
+    'expires_at',
+    'refresh_token',
+    'refresh_token_expires_at',
+]);
+
+it('has fillable attributes', function (string $attribute, mixed $set, mixed $get) {
+    $accessToken = AccessToken::factory()->make();
+    $accessToken->fill([$attribute => $set]);
+    $accessToken->save();
+    $accessToken->refresh();
+
+    expect($accessToken->{$attribute})->toBe($get);
+})->with([
+    ['token', 'shpat_test_token', 'shpat_test_token'],
+    ['mode', 'offline', AccessTokenMode::Offline],
+    ['scopes', ['read_products', 'write_products'], ['read_products', 'write_products']],
+]);
+
+describe('relationships', function () {
+    it('belongs to a shop', function () {
+        $shop = Shop::factory()->create();
+        $accessToken = AccessToken::factory()->create(['shop_id' => $shop->id]);
+
+        expect($accessToken->shop)->toBeInstanceOf(Shop::class)
+            ->and($accessToken->shop->is($shop))->toBeTrue();
+    });
+
+    it('is accessible from shop via hasOne', function () {
+        $shop = Shop::factory()->create();
+        $accessToken = AccessToken::factory()->create(['shop_id' => $shop->id]);
+
+        expect($shop->accessToken)->toBeInstanceOf(AccessToken::class)
+            ->and($shop->accessToken->is($accessToken))->toBeTrue();
+    });
+});
+
+describe('methods', function () {
+    it('converts scopes to a string', function () {
+        $scopes = ['read_products', 'write_orders'];
+
+        $accessToken = AccessToken::factory()->create(['scopes' => $scopes]);
+
+        expect($accessToken->getScopeString())->toBe('read_products,write_orders');
+    });
+});

--- a/web/tests/Feature/Models/ShopTest.php
+++ b/web/tests/Feature/Models/ShopTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Shop;
+use App\Services\Shopify\ShopifyShop;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+pest()->group('models', 'shop');
+
+it('can be created using the factory', function () {
+    $shop = Shop::factory()->create();
+
+    expect($shop)->toBeInstanceOf(Shop::class)
+        ->and($shop->id)->toBeInt()
+        ->and($shop->shop_domain)->toEndWith('.myshopify.com')
+        ->and($shop->name)->toBeString()
+        ->and($shop->email)->toContain('@');
+});
+
+it('has fillable attributes', function (string $attribute, mixed $set, mixed $get) {
+    $shop = Shop::factory()->make();
+    $shop->fill([$attribute => $set]);
+    $shop->save();
+    $shop->refresh();
+
+    expect($shop->{$attribute})->toBe($get);
+})->with([
+    ['shop_domain', 'demo-shop.myshopify.com', 'demo-shop.myshopify.com'],
+    ['name', 'Test Shop', 'Test Shop'],
+    ['email', 'owner@test-shop.com', 'owner@test-shop.com'],
+]);
+
+it('allows nullable attributes to be null', function (string $attribute) {
+    $shop = Shop::factory()->create([$attribute => null]);
+    $shop->refresh();
+
+    expect($shop->{$attribute})->toBeNull();
+})->with([
+    'name',
+    'email',
+]);
+
+it('extracts the Shopify subdomain from the shop domain', function () {
+    $shop = Shop::factory()->create(['shop_domain' => 'my-awesome-shop.myshopify.com']);
+
+    expect($shop->getShopifySubdomain())->toBe('my-awesome-shop');
+});
+
+describe('Authenticatable', function () {
+    it('implements the Authenticatable interface', function () {
+        $shop = Shop::factory()->create();
+
+        expect($shop)->toBeInstanceOf(Authenticatable::class);
+    });
+
+    it('uses shop_domain as the auth identifier', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'auth-test.myshopify.com']);
+
+        expect($shop->getAuthIdentifierName())->toBe('shop_domain')
+            ->and($shop->getAuthIdentifier())->toBe('auth-test.myshopify.com');
+    });
+});
+
+it('exposes a ShopifyShop facade via shopify()', function () {
+    config([
+        'shopify.client_id' => 'test-client-id',
+        'shopify.client_secret' => 'test-client-secret',
+    ]);
+
+    $shop = Shop::factory()->create();
+
+    expect($shop->shopify())->toBeInstanceOf(ShopifyShop::class);
+});

--- a/web/tests/Feature/Webhooks/ShopifyWebhookTest.php
+++ b/web/tests/Feature/Webhooks/ShopifyWebhookTest.php
@@ -1,0 +1,298 @@
+<?php
+
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Webhooks\Handlers\AppUninstalledHandler;
+use App\Services\Shopify\Webhooks\ShopifyWebhook;
+use App\Services\Shopify\Webhooks\WebhookDispatcher;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Shopify\App\ShopifyApp;
+
+pest()->group('webhooks', 'controllers');
+
+beforeEach(function () {
+    config([
+        'shopify.client_id' => 'test-client-id',
+        'shopify.client_secret' => 'test-client-secret',
+    ]);
+
+    // The ShopifyApp singleton captures config at construction time, so make
+    // sure it is rebuilt with the test credentials above.
+    app()->forgetInstance(ShopifyApp::class);
+});
+
+/**
+ * Send a webhook request to the canonical endpoint, signed like Shopify would.
+ *
+ * Each call gets a fresh webhook id unless one is given explicitly. Pass an
+ * empty string to omit the header (like `shopify app webhook trigger` does).
+ *
+ * @param  array<string, mixed>  $payload
+ */
+function postSignedWebhook(
+    string $topic,
+    array $payload = [],
+    string $shopDomain = 'test-shop.myshopify.com',
+    ?string $hmac = null,
+    ?string $webhookId = null,
+    ?string $eventId = null,
+): TestResponse {
+    $body = json_encode($payload, JSON_THROW_ON_ERROR);
+
+    $hmac ??= base64_encode(hash_hmac('sha256', $body, config('shopify.client_secret'), true));
+    $webhookId ??= (string) Str::uuid();
+    $eventId ??= (string) Str::uuid();
+
+    $server = [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_X_SHOPIFY_TOPIC' => $topic,
+        'HTTP_X_SHOPIFY_HMAC_SHA256' => $hmac,
+        'HTTP_X_SHOPIFY_SHOP_DOMAIN' => $shopDomain,
+        'HTTP_X_SHOPIFY_API_VERSION' => '2026-04',
+    ];
+
+    if ($webhookId !== '') {
+        $server['HTTP_X_SHOPIFY_WEBHOOK_ID'] = $webhookId;
+    }
+
+    if ($eventId !== '') {
+        $server['HTTP_X_SHOPIFY_EVENT_ID'] = $eventId;
+    }
+
+    return test()->call('POST', '/webhooks/shopify', server: $server, content: $body);
+}
+
+describe('HMAC verification', function () {
+    it('rejects a webhook with an invalid HMAC signature', function () {
+        $response = postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], hmac: base64_encode('not-the-right-signature'));
+
+        $response->assertUnauthorized();
+    });
+
+    it('rejects a webhook signed with the wrong secret', function () {
+        $body = json_encode(['domain' => 'test-shop.myshopify.com']);
+        $wrongHmac = base64_encode(hash_hmac('sha256', $body, 'wrong-secret', true));
+
+        $response = postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], hmac: $wrongHmac);
+
+        $response->assertUnauthorized();
+    });
+
+    it('rejects a webhook with a missing HMAC header', function () {
+        $body = json_encode(['domain' => 'test-shop.myshopify.com']);
+
+        $response = $this->call('POST', '/webhooks/shopify', server: [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_SHOPIFY_TOPIC' => 'app/uninstalled',
+            'HTTP_X_SHOPIFY_SHOP_DOMAIN' => 'test-shop.myshopify.com',
+        ], content: $body);
+
+        $response->assertBadRequest();
+    });
+
+    it('accepts a webhook with a valid HMAC signature', function () {
+        $response = postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com']);
+
+        $response->assertOk();
+    });
+
+    it('does not touch any shop when the HMAC is invalid', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'test-shop.myshopify.com']);
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+
+        postSignedWebhook('app/uninstalled', ['domain' => $shop->shop_domain], shopDomain: $shop->shop_domain, hmac: base64_encode('invalid'));
+
+        expect($shop->refresh()->uninstalled_at)->toBeNull()
+            ->and($shop->accessToken)->not->toBeNull();
+    });
+});
+
+describe('topic dispatch', function () {
+    it('dispatches the webhook to the handler registered for the topic', function () {
+        $spy = $this->spy(AppUninstalledHandler::class);
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1', eventId: 'event-id-1')->assertOk();
+
+        $spy->shouldHaveReceived('handle')
+            ->once()
+            ->withArgs(fn (ShopifyWebhook $webhook) => $webhook->topic === 'app/uninstalled'
+                && $webhook->shopDomain === 'test-shop.myshopify.com'
+                && $webhook->webhookId === 'webhook-id-1'
+                && $webhook->eventId === 'event-id-1'
+                && $webhook->apiVersion === '2026-04'
+                && $webhook->payload === ['domain' => 'test-shop.myshopify.com']);
+    });
+
+    it('acknowledges a topic without a registered handler with a 200', function () {
+        postSignedWebhook('products/create', ['id' => 123])->assertOk();
+    });
+
+    it('has a handler registered for every topic declared in shopify.app.toml', function (string $topic) {
+        $handlers = (fn () => $this->handlers)->call(app(WebhookDispatcher::class));
+
+        expect($handlers)->toHaveKey($topic);
+    })->with([
+        'app/uninstalled',
+        'customers/data_request',
+        'customers/redact',
+        'shop/redact',
+    ]);
+});
+
+describe('idempotency', function () {
+    it('keeps holding the webhook id lock after successful processing', function () {
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1', eventId: 'event-id-1')->assertOk();
+
+        // The held lock IS the dedup record: it must not be released on
+        // success, so it cannot be re-acquired.
+        expect(Cache::lock('shopify-webhook:webhook-id-1', 10)->get())->toBeFalse();
+    });
+
+    it('skips a duplicate delivery, responds with success and logs the duplicate', function () {
+        $spy = $this->spy(AppUninstalledHandler::class);
+        Log::spy();
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1', eventId: 'event-id-1')->assertOk();
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1', eventId: 'event-id-1')->assertOk();
+
+        $spy->shouldHaveReceived('handle')->once();
+
+        Log::shouldHaveReceived('info')
+            ->with('Skipping duplicate Shopify webhook delivery - webhook id has already been processed', [
+                'webhook_id' => 'webhook-id-1',
+                'event_id' => 'event-id-1',
+                'topic' => 'app/uninstalled',
+                'shop_domain' => 'test-shop.myshopify.com',
+            ])
+            ->once();
+    });
+
+    it('treats a webhook id whose lock is held by a concurrent delivery as a duplicate', function () {
+        // Simulates losing the race against a concurrent identical delivery:
+        // the claim is an atomic cache lock on the webhook id, so a lock that
+        // is already held means another request already won.
+        Cache::lock('shopify-webhook:webhook-id-1', 60)->get();
+
+        $spy = $this->spy(AppUninstalledHandler::class);
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1')->assertOk();
+
+        $spy->shouldNotHaveReceived('handle');
+    });
+
+    it('processes deliveries with different webhook ids even when they share an event id', function () {
+        $spy = $this->spy(AppUninstalledHandler::class);
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1', eventId: 'shared-event-id')->assertOk();
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-2', eventId: 'shared-event-id')->assertOk();
+
+        $spy->shouldHaveReceived('handle')->twice();
+    });
+
+    it('processes a delivery without a webhook id header and logs a warning', function () {
+        $spy = $this->spy(AppUninstalledHandler::class);
+        Log::spy();
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: '', eventId: '')->assertOk();
+
+        $spy->shouldHaveReceived('handle')->once();
+
+        Log::shouldHaveReceived('warning')
+            ->with('Shopify webhook delivered without X-Shopify-Webhook-Id header - skipping deduplication', Mockery::type('array'))
+            ->once();
+    });
+
+    it('releases the lock when the handler throws so the retry is processed', function () {
+        $this->mock(AppUninstalledHandler::class)
+            ->shouldReceive('handle')
+            ->once()
+            ->andThrow(new RuntimeException('Handler failed'));
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1')->assertServerError();
+
+        // Shopify retries with the same webhook id - the retry must be processed.
+        $spy = $this->spy(AppUninstalledHandler::class);
+
+        postSignedWebhook('app/uninstalled', ['domain' => 'test-shop.myshopify.com'], webhookId: 'webhook-id-1')->assertOk();
+
+        $spy->shouldHaveReceived('handle')->once();
+    });
+});
+
+describe('app/uninstalled', function () {
+    it('deletes the access token and marks the shop as uninstalled', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'test-shop.myshopify.com']);
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+
+        postSignedWebhook('app/uninstalled', ['domain' => $shop->shop_domain], shopDomain: $shop->shop_domain)->assertOk();
+
+        $shop->refresh();
+
+        expect($shop->uninstalled_at)->not->toBeNull()
+            ->and($shop->accessToken)->toBeNull();
+
+        $this->assertDatabaseCount('access_tokens', 0);
+    });
+
+    it('responds 200 even when the shop is unknown', function () {
+        postSignedWebhook('app/uninstalled', ['domain' => 'unknown.myshopify.com'], shopDomain: 'unknown.myshopify.com')->assertOk();
+    });
+});
+
+describe('compliance topics', function () {
+    it('acknowledges a customers/data_request webhook', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'test-shop.myshopify.com']);
+
+        postSignedWebhook('customers/data_request', [
+            'shop_id' => 1,
+            'shop_domain' => $shop->shop_domain,
+            'customer' => ['id' => 42, 'email' => 'customer@example.com'],
+            'orders_requested' => [299938, 280263],
+            'data_request' => ['id' => 9999],
+        ], shopDomain: $shop->shop_domain)->assertOk();
+    });
+
+    it('acknowledges a customers/redact webhook', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'test-shop.myshopify.com']);
+
+        postSignedWebhook('customers/redact', [
+            'shop_id' => 1,
+            'shop_domain' => $shop->shop_domain,
+            'customer' => ['id' => 42, 'email' => 'customer@example.com'],
+            'orders_to_redact' => [299938, 280263],
+        ], shopDomain: $shop->shop_domain)->assertOk();
+    });
+
+    it('deletes the shop and access token on shop/redact', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'test-shop.myshopify.com']);
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+
+        postSignedWebhook('shop/redact', [
+            'shop_id' => 1,
+            'shop_domain' => $shop->shop_domain,
+        ], shopDomain: $shop->shop_domain)->assertOk();
+
+        $this->assertDatabaseMissing('shops', ['shop_domain' => $shop->shop_domain]);
+        $this->assertDatabaseCount('access_tokens', 0);
+    });
+
+    it('responds 200 to shop/redact for an unknown shop', function () {
+        postSignedWebhook('shop/redact', [
+            'shop_id' => 1,
+            'shop_domain' => 'unknown.myshopify.com',
+        ], shopDomain: 'unknown.myshopify.com')->assertOk();
+    });
+});
+
+describe('routing', function () {
+    it('registers the canonical webhook route', function () {
+        expect(route('webhooks.shopify'))->toEndWith('/webhooks/shopify');
+    });
+
+    it('rejects non-POST requests', function () {
+        $this->get('/webhooks/shopify')->assertStatus(405);
+    });
+});

--- a/web/tests/Pest.php
+++ b/web/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\AccessToken;
+use App\Models\Shop;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -15,8 +17,16 @@ use Tests\TestCase;
 */
 
 pest()->extend(TestCase::class)
- // ->use(RefreshDatabase::class)
+    ->use(RefreshDatabase::class)
     ->in('Feature');
+
+pest()->extend(TestCase::class)
+    ->in('Unit');
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->group('contract')
+    ->in('Contract');
 
 /*
 |--------------------------------------------------------------------------
@@ -47,4 +57,123 @@ expect()->extend('toBeOne', function () {
 function something()
 {
     // ..
+}
+
+/**
+ * CI fallback credentials for the Contract tier: the TEST_STORE_DOMAIN +
+ * TEST_STORE_OFFLINE_TOKEN env vars, set as secrets where there is no local dev
+ * database to read from. Locally the dev database is used instead — see
+ * {@see contractShop()}.
+ *
+ * Returns null when unset so callers can skip cleanly.
+ *
+ * @return array{domain: string, token: string}|null
+ */
+function testStoreCredentials(): ?array
+{
+    $domain = env('TEST_STORE_DOMAIN');
+    $token = env('TEST_STORE_OFFLINE_TOKEN');
+
+    if (empty($domain) || empty($token)) {
+        return null;
+    }
+
+    return ['domain' => $domain, 'token' => $token];
+}
+
+/**
+ * The installed shop in the local dev database (the one `shopify app dev`
+ * installs and keeps refreshed). Returns null when there is no dev database
+ * (e.g. CI) or no installed shop.
+ *
+ * The connection to the dev sqlite file is defined here on demand — test-only,
+ * read-only — so it never enters the production `config/database.php`. Pinned to
+ * the real file via its own env var so the testing `:memory:` DB_DATABASE
+ * override can't point it elsewhere.
+ */
+function devDatabaseShop(): ?Shop
+{
+    config([
+        'database.connections.shopify_dev' => [
+            'driver' => 'sqlite',
+            'database' => env('SHOPIFY_DEV_DATABASE', database_path('database.sqlite')),
+            'prefix' => '',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+        ],
+    ]);
+
+    try {
+        return Shop::on('shopify_dev')->whereHas('accessToken')->latest('id')->first();
+    } catch (Throwable) {
+        return null;
+    }
+}
+
+/**
+ * Whether a dev-database token is safe to copy and use without triggering a
+ * refresh during the test. A refresh would rotate Shopify's single-use refresh
+ * token and invalidate the dev install; we'd rather skip and let `npm run dev`
+ * keep the token fresh. The margin sits comfortably above the proactive-refresh
+ * buffer so a quick test never crosses it mid-run.
+ */
+function devTokenUsable(Shop $shop): bool
+{
+    $token = $shop->accessToken;
+
+    return $token !== null
+        && ($token->expires_at === null || $token->expires_at->isAfter(now()->addMinutes(5)));
+}
+
+/**
+ * Resolve a Shop for the Contract tier, bound to a real, usable offline token.
+ *
+ * Locally it copies the live shop + offline token out of the dev database into
+ * the isolated (rolled-back) test database, so the contract shop is an ordinary
+ * fixture on the default connection — visible to in-process artisan commands.
+ * Only a comfortably valid token is copied (see {@see devTokenUsable()}), so the
+ * test never refreshes; when the dev token is near expiry the resolver returns
+ * null and the test skips. In CI (no dev database) it falls back to the
+ * TEST_STORE_* env secrets. Returns null when neither is available.
+ */
+function contractShop(): ?Shop
+{
+    $dev = devDatabaseShop();
+
+    if ($dev !== null && devTokenUsable($dev)) {
+        $shop = Shop::factory()->create(['shop_domain' => $dev->shop_domain]);
+        AccessToken::factory()->for($shop)->create([
+            'token' => $dev->accessToken->token,
+            'mode' => $dev->accessToken->mode,
+            'scopes' => $dev->accessToken->scopes,
+            'expires_at' => $dev->accessToken->expires_at,
+            'refresh_token' => $dev->accessToken->refresh_token,
+            'refresh_token_expires_at' => $dev->accessToken->refresh_token_expires_at,
+        ]);
+        $shop->refresh();
+
+        return $shop;
+    }
+
+    $credentials = testStoreCredentials();
+
+    if ($credentials === null) {
+        return null;
+    }
+
+    $shop = Shop::factory()->create(['shop_domain' => $credentials['domain']]);
+    AccessToken::factory()->for($shop)->offlineNonExpiring()->create(['token' => $credentials['token']]);
+    $shop->refresh();
+
+    return $shop;
+}
+
+/**
+ * Whether a Contract-tier shop can be resolved — a usable local dev install or
+ * the CI env secrets — without creating anything. Used by Contract skip guards.
+ */
+function contractShopAvailable(): bool
+{
+    $dev = devDatabaseShop();
+
+    return ($dev !== null && devTokenUsable($dev)) || testStoreCredentials() !== null;
 }

--- a/web/tests/TestCase.php
+++ b/web/tests/TestCase.php
@@ -6,5 +6,17 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure ShopifyApp can construct without a real .env. AppServiceProvider
+        // reads config('shopify.client_id') / client_secret when the apphome
+        // guard is first resolved (e.g. via actingAs); without these fakes the
+        // shopify-app-php constructor throws.
+        config([
+            'shopify.client_id' => config('shopify.client_id') ?: 'test-client-id',
+            'shopify.client_secret' => config('shopify.client_secret') ?: 'test-client-secret',
+        ]);
+    }
 }

--- a/web/tests/Unit/Actions/Auth/CreateShopActionTest.php
+++ b/web/tests/Unit/Actions/Auth/CreateShopActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Actions\Auth\CreateShopAction;
+use App\Models\Shop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+
+uses(RefreshDatabase::class);
+
+pest()->group('actions', 'auth');
+
+it('creates a shop with the given domain', function () {
+    $action = new CreateShopAction;
+    $shopDomain = 'test-shop.myshopify.com';
+
+    $shop = $action->execute($shopDomain);
+
+    expect($shop)->toBeInstanceOf(Shop::class)
+        ->and($shop->shop_domain)->toBe($shopDomain)
+        ->and($shop->exists)->toBeTrue();
+});
+
+it('persists the shop to the database', function () {
+    $action = new CreateShopAction;
+    $shopDomain = 'persisted-shop.myshopify.com';
+
+    $action->execute($shopDomain);
+
+    $this->assertDatabaseHas('shops', [
+        'shop_domain' => $shopDomain,
+    ]);
+});
+
+it('logs the shop creation', function () {
+    Log::spy();
+
+    $action = new CreateShopAction;
+    $shopDomain = 'logged-shop.myshopify.com';
+
+    $action->execute($shopDomain);
+
+    Log::shouldHaveReceived('info')
+        ->once()
+        ->with('Creating new Shop-model', ['shop_domain' => $shopDomain]);
+});
+
+it('returns the created shop with an id', function () {
+    $action = new CreateShopAction;
+    $shopDomain = 'shop-with-id.myshopify.com';
+
+    $shop = $action->execute($shopDomain);
+
+    expect($shop->id)->toBeInt()
+        ->and($shop->id)->toBeGreaterThan(0);
+});

--- a/web/tests/Unit/Actions/Auth/SaveTokenExchangeAccessTokenActionTest.php
+++ b/web/tests/Unit/Actions/Auth/SaveTokenExchangeAccessTokenActionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Actions\Auth\SaveTokenExchangeAccessTokenAction;
+use App\Enums\AccessTokenMode;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\Types\TokenExchangeAccessToken;
+
+uses(RefreshDatabase::class);
+
+pest()->group('actions', 'auth');
+
+it('creates an access token for a shop', function () {
+    $shop = Shop::factory()->create();
+    $tokenExchange = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->shop_domain,
+        token: 'shpat_test_token_12345',
+        expires: '2025-12-31T23:59:59Z',
+        scope: 'read_products,write_orders',
+        refreshToken: 'shprt_refresh_token_12345',
+        refreshTokenExpires: '2026-06-30T23:59:59Z',
+        user: null,
+    );
+
+    $action = new SaveTokenExchangeAccessTokenAction;
+    $accessToken = $action->execute($shop, $tokenExchange);
+
+    expect($accessToken)->toBeInstanceOf(AccessToken::class)
+        ->and($accessToken->token)->toBe('shpat_test_token_12345')
+        ->and($accessToken->mode)->toBe(AccessTokenMode::Offline)
+        ->and($accessToken->scopes)->toBe(['read_products', 'write_orders'])
+        ->and($accessToken->refresh_token)->toBe('shprt_refresh_token_12345');
+});
+
+it('updates existing access token instead of creating a new one', function () {
+    $shop = Shop::factory()->create();
+    $existingToken = AccessToken::factory()->create([
+        'shop_id' => $shop->id,
+        'token' => 'old_token',
+    ]);
+
+    $tokenExchange = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->shop_domain,
+        token: 'new_token',
+        expires: null,
+        scope: 'read_products',
+        refreshToken: '',
+        refreshTokenExpires: null,
+        user: null,
+    );
+
+    $action = new SaveTokenExchangeAccessTokenAction;
+    $action->execute($shop, $tokenExchange);
+
+    expect(AccessToken::where('shop_id', $shop->id)->count())->toBe(1);
+    $existingToken->refresh();
+    expect($existingToken->token)->toBe('new_token');
+});
+
+it('reloads the accessToken relationship on the shop', function () {
+    $shop = Shop::factory()->create();
+    // Pre-load the relationship (to simulate it being cached as null)
+    $shop->load('accessToken');
+
+    $tokenExchange = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->shop_domain,
+        token: 'shpat_new_token',
+        expires: null,
+        scope: 'read_products',
+        refreshToken: '',
+        refreshTokenExpires: null,
+        user: null,
+    );
+
+    $action = new SaveTokenExchangeAccessTokenAction;
+    $action->execute($shop, $tokenExchange);
+
+    // The relationship should be reloaded, not null
+    expect($shop->accessToken)->not->toBeNull()
+        ->and($shop->accessToken->token)->toBe('shpat_new_token');
+});
+
+it('logs the saved access token', function () {
+    Log::spy();
+
+    $shop = Shop::factory()->create();
+    $tokenExchange = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->shop_domain,
+        token: 'shpat_logged_token',
+        expires: null,
+        scope: 'read_products',
+        refreshToken: '',
+        refreshTokenExpires: null,
+        user: null,
+    );
+
+    $action = new SaveTokenExchangeAccessTokenAction;
+    $accessToken = $action->execute($shop, $tokenExchange);
+
+    Log::shouldHaveReceived('info')
+        ->once()
+        ->with('Saved AccessToken-model', [
+            'shop_id' => $shop->id,
+            'access_token_id' => $accessToken->id,
+        ]);
+});
+
+it('correctly parses comma-separated scopes', function () {
+    $shop = Shop::factory()->create();
+    $tokenExchange = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->shop_domain,
+        token: 'shpat_scope_test',
+        expires: null,
+        scope: 'read_products,write_orders,read_customers,write_fulfillments',
+        refreshToken: '',
+        refreshTokenExpires: null,
+        user: null,
+    );
+
+    $action = new SaveTokenExchangeAccessTokenAction;
+    $accessToken = $action->execute($shop, $tokenExchange);
+
+    expect($accessToken->scopes)->toBe([
+        'read_products',
+        'write_orders',
+        'read_customers',
+        'write_fulfillments',
+    ]);
+});

--- a/web/tests/Unit/Actions/RefreshAccessTokenActionTest.php
+++ b/web/tests/Unit/Actions/RefreshAccessTokenActionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Actions\Auth\SaveTokenExchangeAccessTokenAction;
+use App\Actions\RefreshAccessTokenAction;
+use App\Events\ShopifyAccessTokenRefreshed;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\AccessTokenStillValidException;
+use App\Services\Shopify\Exceptions\ShopifyServerErrorException;
+use App\Services\Shopify\ShopifyShop;
+use App\Services\Shopify\ShopifyShopFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+use Shopify\App\Types\TokenExchangeAccessToken;
+use Shopify\App\Types\TokenExchangeResult;
+
+uses(RefreshDatabase::class);
+
+pest()->group('actions', 'refresh-access-token');
+
+it('refreshes, saves, and dispatches event', function () {
+    Event::fake();
+
+    $shop = Shop::factory()->create();
+    AccessToken::factory()->for($shop)->offline()->create();
+    $shop->refresh();
+
+    $newToken = new TokenExchangeAccessToken(
+        accessMode: 'offline',
+        shop: $shop->getShopifySubdomain(),
+        token: 'shpat_refreshed_token',
+        expires: '2026-12-31T23:59:59Z',
+        scope: 'read_products,write_orders',
+        refreshToken: 'shprt_new_refresh',
+        refreshTokenExpires: '2027-06-30T23:59:59Z',
+        user: null,
+    );
+
+    $mockShopifyShop = Mockery::mock(ShopifyShop::class);
+    $mockShopifyShop->shouldReceive('refreshAccessToken')
+        ->once()
+        ->andReturn($newToken);
+
+    $mockFactory = Mockery::mock(ShopifyShopFactory::class);
+    $mockFactory->shouldReceive('forShop')
+        ->with($shop)
+        ->once()
+        ->andReturn($mockShopifyShop);
+
+    $action = new RefreshAccessTokenAction(
+        shopifyServiceFactory: $mockFactory,
+        saveTokenAction: new SaveTokenExchangeAccessTokenAction,
+    );
+
+    $result = $action->execute($shop);
+
+    expect($result)->toBeInstanceOf(AccessToken::class)
+        ->and($result->token)->toBe('shpat_refreshed_token');
+
+    Event::assertDispatched(ShopifyAccessTokenRefreshed::class, function ($event) use ($shop) {
+        return $event->shop->is($shop);
+    });
+});
+
+it('treats a still-valid token as a no-op and returns the existing token', function () {
+    Event::fake();
+
+    $shop = Shop::factory()->create();
+    $token = AccessToken::factory()->for($shop)->offline()->create();
+    $shop->refresh();
+
+    $mockShopifyShop = Mockery::mock(ShopifyShop::class);
+    $mockShopifyShop->shouldReceive('refreshAccessToken')
+        ->once()
+        ->andThrow(new AccessTokenStillValidException);
+
+    $mockFactory = Mockery::mock(ShopifyShopFactory::class);
+    $mockFactory->shouldReceive('forShop')->once()->andReturn($mockShopifyShop);
+
+    $action = new RefreshAccessTokenAction(
+        shopifyServiceFactory: $mockFactory,
+        saveTokenAction: new SaveTokenExchangeAccessTokenAction,
+    );
+
+    $result = $action->execute($shop);
+
+    expect($result->id)->toBe($token->id);
+
+    Event::assertNotDispatched(ShopifyAccessTokenRefreshed::class);
+});
+
+it('propagates ShopifyAuthException subclasses from the underlying refresh', function () {
+    $shop = Shop::factory()->create();
+    AccessToken::factory()->for($shop)->offline()->create();
+    $shop->refresh();
+
+    $mockShopifyShop = Mockery::mock(ShopifyShop::class);
+    $mockShopifyShop->shouldReceive('refreshAccessToken')
+        ->once()
+        ->andThrow(new ShopifyServerErrorException(
+            new TokenExchangeResult(
+                ok: false,
+                shop: $shop->getShopifySubdomain(),
+                accessToken: null,
+                log: new Log(code: 'server_error', detail: 'Failed'),
+                httpLogs: [],
+                response: new ResponseInfo(status: 500, body: '', headers: (object) []),
+            ),
+        ));
+
+    $mockFactory = Mockery::mock(ShopifyShopFactory::class);
+    $mockFactory->shouldReceive('forShop')->once()->andReturn($mockShopifyShop);
+
+    $action = new RefreshAccessTokenAction(
+        shopifyServiceFactory: $mockFactory,
+        saveTokenAction: new SaveTokenExchangeAccessTokenAction,
+    );
+
+    $action->execute($shop);
+})->throws(ShopifyServerErrorException::class);
+
+it('does not dispatch event on failure', function () {
+    Event::fake();
+
+    $shop = Shop::factory()->create();
+    AccessToken::factory()->for($shop)->offline()->create();
+    $shop->refresh();
+
+    $mockShopifyShop = Mockery::mock(ShopifyShop::class);
+    $mockShopifyShop->shouldReceive('refreshAccessToken')
+        ->once()
+        ->andThrow(new ShopifyServerErrorException(
+            new TokenExchangeResult(
+                ok: false,
+                shop: $shop->getShopifySubdomain(),
+                accessToken: null,
+                log: new Log(code: 'server_error', detail: 'Failed'),
+                httpLogs: [],
+                response: new ResponseInfo(status: 500, body: '', headers: (object) []),
+            ),
+        ));
+
+    $mockFactory = Mockery::mock(ShopifyShopFactory::class);
+    $mockFactory->shouldReceive('forShop')->once()->andReturn($mockShopifyShop);
+
+    $action = new RefreshAccessTokenAction(
+        shopifyServiceFactory: $mockFactory,
+        saveTokenAction: new SaveTokenExchangeAccessTokenAction,
+    );
+
+    try {
+        $action->execute($shop);
+    } catch (ShopifyServerErrorException) {
+        // Expected
+    }
+
+    Event::assertNotDispatched(ShopifyAccessTokenRefreshed::class);
+});

--- a/web/tests/Unit/Auth/ShopifyAppHomeGuardTest.php
+++ b/web/tests/Unit/Auth/ShopifyAppHomeGuardTest.php
@@ -1,0 +1,436 @@
+<?php
+
+use App\Auth\Guards\ShopifyAppHomeGuard;
+use App\Enums\AccessTokenMode;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\ShopifyCredentialMismatchException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\IdToken;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\LogWithReq;
+use Shopify\App\Types\ResponseInfo;
+use Shopify\App\Types\ResultWithExchangeableIdToken;
+use Shopify\App\Types\TokenExchangeAccessToken;
+use Shopify\App\Types\TokenExchangeResult;
+
+pest()->use(RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'shopify.client_id' => 'test-client-id',
+        'shopify.client_secret' => 'test-client-secret',
+    ]);
+});
+
+it('shopify app home guard registered', function () {
+    $guard = Auth::guard('apphome');
+
+    expect($guard)->toBeInstanceOf(ShopifyAppHomeGuard::class);
+});
+
+it('can set Shop model as the authenticated user via Auth facade', function () {
+    $shop = Shop::factory()->create();
+
+    Auth::guard('apphome')->setUser($shop);
+
+    expect(Auth::guard('apphome')->check())->toBeTrue()
+        ->and(Auth::guard('apphome')->user())->toBe($shop)
+        ->and(Auth::guard('apphome')->id())->toBe($shop->shop_domain);
+});
+
+it('returns null when invalid token', function () {
+    $mockShopify = Mockery::mock(ShopifyApp::class);
+    $mockShopify->shouldReceive('verifyAppHomeReq')
+        ->once()
+        ->andReturn(new ResultWithExchangeableIdToken(
+            ok: false,
+            shop: null,
+            idToken: null,
+            userId: null,
+            newIdTokenResponse: null,
+            log: new LogWithReq(
+                code: 'invalid_token',
+                detail: 'Token verification failed',
+                req: []
+            ),
+            response: new ResponseInfo(
+                status: 401,
+                body: 'Unauthorized',
+                headers: []
+            )
+        ));
+
+    $this->app->instance(ShopifyApp::class, $mockShopify);
+
+    $guard = Auth::guard('apphome');
+
+    expect($guard->check())->toBeFalse()
+        ->and($guard->user())->toBeNull();
+});
+
+describe('credential mismatch diagnostic', function () {
+    $mockVerify = function (string $code): void {
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('verifyAppHomeReq')
+            ->andReturn(new ResultWithExchangeableIdToken(
+                ok: false,
+                shop: null,
+                idToken: null,
+                userId: null,
+                newIdTokenResponse: null,
+                log: new LogWithReq(code: $code, detail: $code, req: []),
+                response: new ResponseInfo(status: 401, body: 'Unauthorized', headers: []),
+            ));
+
+        app()->instance(ShopifyApp::class, $mockShopify);
+    };
+
+    // Bind the request the guard inspects, optionally carrying an id_token via
+    // the Authorization bearer (XHR) or the document `id_token` query.
+    $bindRequest = function (array $query = [], ?string $bearer = null): void {
+        $request = Request::create('/', 'GET', $query);
+
+        if ($bearer !== null) {
+            $request->headers->set('Authorization', "Bearer {$bearer}");
+        }
+
+        app()->instance('request', $request);
+    };
+
+    $jwt = function (array $claims): string {
+        $segment = fn (array $data) => rtrim(strtr(base64_encode(json_encode($data)), '+/', '-_'), '=');
+
+        return $segment(['alg' => 'HS256', 'typ' => 'JWT']).'.'.$segment($claims).'.'.$segment(['sig']);
+    };
+
+    // `invalid_aud` means the signature verified (the secret is right) but the
+    // audience did not — a trustworthy, non-spoofable wrong-client_id signal.
+    it('throws naming the client id on invalid_aud', function () use ($mockVerify) {
+        config(['shopify.client_id' => 'configured-client-id']);
+        $mockVerify('invalid_aud');
+
+        expect(fn () => Auth::guard('apphome')->user())
+            ->toThrow(ShopifyCredentialMismatchException::class, 'SHOPIFY_CLIENT_ID');
+    });
+
+    it('throws on a misconfiguration even with debug off, so it is reported', function () use ($mockVerify) {
+        config(['app.debug' => false]);
+        $mockVerify('invalid_aud');
+
+        expect(fn () => Auth::guard('apphome')->user())
+            ->toThrow(ShopifyCredentialMismatchException::class);
+    });
+
+    it('exposes structured reason context without leaking the secret', function () use ($mockVerify) {
+        config(['shopify.client_id' => 'configured-client-id']);
+        $mockVerify('invalid_aud');
+
+        try {
+            Auth::guard('apphome')->user();
+            test()->fail('Expected a credential mismatch exception.');
+        } catch (ShopifyCredentialMismatchException $e) {
+            expect($e->context())->toBe([
+                'shopify_reason_code' => 'invalid_aud',
+                'configured_client_id' => 'configured-client-id',
+            ]);
+        }
+    });
+
+    // A signature failure (invalid_id_token / patch redirect) is only a wrong
+    // secret when the rejected token is still unexpired; a stale or absent token
+    // is recoverable and must NOT throw (the middleware returns the package's
+    // retry / patch-redirect response instead).
+    it('throws naming the client secret when an unexpired bearer token fails signature', function () use ($mockVerify, $bindRequest, $jwt) {
+        $bindRequest(bearer: $jwt(['exp' => time() + 300]));
+        $mockVerify('invalid_id_token');
+
+        expect(fn () => Auth::guard('apphome')->user())
+            ->toThrow(ShopifyCredentialMismatchException::class, 'SHOPIFY_CLIENT_SECRET');
+    });
+
+    it('stays recoverable (no throw) for an expired bearer token', function () use ($mockVerify, $bindRequest, $jwt) {
+        $bindRequest(bearer: $jwt(['exp' => time() - 300]));
+        $mockVerify('invalid_id_token');
+
+        expect(Auth::guard('apphome')->user())->toBeNull();
+    });
+
+    it('stays recoverable (no throw) when no token is presented', function () use ($mockVerify, $bindRequest) {
+        $bindRequest();
+        $mockVerify('invalid_id_token');
+
+        expect(Auth::guard('apphome')->user())->toBeNull();
+    });
+
+    // Document loads: a wrong secret surfaces as a patch-id-token redirect with
+    // the rejected (unexpired) token still in the query string.
+    it('throws naming the client secret when an unexpired document token is rejected', function () use ($mockVerify, $bindRequest, $jwt) {
+        $bindRequest(query: ['id_token' => $jwt(['exp' => time() + 300])]);
+        $mockVerify('redirect_to_patch_id_token_page');
+
+        expect(fn () => Auth::guard('apphome')->user())
+            ->toThrow(ShopifyCredentialMismatchException::class, 'SHOPIFY_CLIENT_SECRET');
+    });
+
+    it('stays recoverable on the bootstrap redirect when no document token is present', function () use ($mockVerify, $bindRequest) {
+        $bindRequest();
+        $mockVerify('redirect_to_patch_id_token_page');
+
+        expect(Auth::guard('apphome')->user())->toBeNull();
+    });
+
+    it('stays recoverable for an expired document token', function () use ($mockVerify, $bindRequest, $jwt) {
+        $bindRequest(query: ['id_token' => $jwt(['exp' => time() - 300])]);
+        $mockVerify('redirect_to_patch_id_token_page');
+
+        expect(Auth::guard('apphome')->user())->toBeNull();
+    });
+
+    it('does not treat non-credential failures as a credential mismatch', function () use ($mockVerify, $bindRequest) {
+        $bindRequest();
+        $mockVerify('invalid_token');
+
+        expect(Auth::guard('apphome')->user())->toBeNull();
+    });
+});
+
+describe('authenticates existing shop', function () {
+    it('authenticates with existing valid access token', function () {
+        $shop = Shop::factory()->has(AccessToken::factory()->offline())->create();
+        $shopName = $shop->getShopifySubdomain();
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        // Mock that the request is valid
+        $mockShopify->shouldReceive('verifyAppHomeReq')
+            ->once()
+            ->andReturn(new ResultWithExchangeableIdToken(
+                ok: true,
+                shop: $shopName,
+                idToken: new IdToken(
+                    exchangeable: true,
+                    token: 'test_id_token',
+                    claims: ['sub' => '12345']
+                ),
+                userId: '12345',
+                newIdTokenResponse: null,
+                log: new LogWithReq(
+                    code: 'success',
+                    detail: 'Token verified',
+                    req: []
+                ),
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: []
+                )
+            ));
+        // Mock that the existing access token is valid
+        $mockShopify->shouldReceive('refreshTokenExchangedAccessToken')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: true,
+                shop: $shopName,
+                accessToken: null,
+                log: new Log(
+                    code: 'token_still_valid',
+                    detail: 'Access token is still valid. No refresh needed. Proceed with business logic.'
+                ),
+                httpLogs: [],
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: (object) []
+                )
+            ));
+
+        $this->app->instance(ShopifyApp::class, $mockShopify);
+
+        $auth = Auth::guard('apphome')->user();
+
+        expect($auth->is($shop))->toBeTrue();
+    });
+
+    it('updates existing access token', function () {
+        $shop = Shop::factory()->has(AccessToken::factory()->offline())->create();
+        $shopName = $shop->getShopifySubdomain();
+
+        // This is not stored in DB, we just wanna use the factory definitions to create appropriate values
+        $fakeAccessToken = AccessToken::factory()->offline()->make();
+        $accessToken = [
+            'token' => $fakeAccessToken->token,
+            'expires_at' => $fakeAccessToken->expires_at,
+            'scopes' => $fakeAccessToken->scopes,
+            'refresh_token' => $fakeAccessToken->refresh_token,
+            'refresh_token_expires_at' => $fakeAccessToken->refresh_token_expires_at,
+        ];
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        // Mock that the request is valid
+        $mockShopify->shouldReceive('verifyAppHomeReq')
+            ->once()
+            ->andReturn(new ResultWithExchangeableIdToken(
+                ok: true,
+                shop: $shopName,
+                idToken: new IdToken(
+                    exchangeable: true,
+                    token: 'test_id_token',
+                    claims: ['sub' => '12345']
+                ),
+                userId: '12345',
+                newIdTokenResponse: null,
+                log: new LogWithReq(
+                    code: 'success',
+                    detail: 'Token verified',
+                    req: []
+                ),
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: []
+                )
+            ));
+
+        // Mock that a refreshed token is returned
+        $mockShopify->shouldReceive('refreshTokenExchangedAccessToken')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: true,
+                shop: $shopName,
+                accessToken: new TokenExchangeAccessToken(
+                    accessMode: 'offline',
+                    shop: $shopName,
+                    token: $accessToken['token'],
+                    expires: $accessToken['expires_at']->toIso8601ZuluString(),
+                    scope: implode(',', $accessToken['scopes']),
+                    refreshToken: $accessToken['refresh_token'],
+                    refreshTokenExpires: $accessToken['refresh_token_expires_at']->toIso8601ZuluString(),
+                    user: null
+                ),
+                log: new Log(
+                    code: 'success',
+                    detail: 'Token refresh successful. Store the new access and refresh token then proceed with business logic.'
+                ),
+                httpLogs: [],
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: (object) []
+                )
+            ));
+
+        $this->app->instance(ShopifyApp::class, $mockShopify);
+
+        $guard = Auth::guard('apphome');
+
+        expect($guard->check())->toBeTrue() // Our "once" assumptions above checks that this check reuses the result from $quard->user()
+            ->and($shop)->toBeInstanceOf(Shop::class)
+            ->and($shop->shop_domain)->toBe($shopName.'.myshopify.com')
+            ->and($shop->accessToken)->toBeInstanceOf(AccessToken::class)
+            ->and($shop->accessToken->token)->toBe($accessToken['token'])
+            ->and($shop->accessToken->mode)->toBe(AccessTokenMode::Offline)
+            ->and($shop->accessToken->scopes)->toEqual($accessToken['scopes'])
+            ->and($shop->accessToken->expires_at)->toEqual($accessToken['expires_at'])
+            ->and($shop->accessToken->refresh_token)->toBe($accessToken['refresh_token'])
+            ->and($shop->accessToken->refresh_token_expires_at)->toEqual($accessToken['refresh_token_expires_at']);
+    });
+
+    test('redirects when refresh token is expired', function () {
+        $shop = Shop::factory()
+            ->has(AccessToken::factory()
+                ->offline()
+                ->expiredRefreshToken()
+
+            )->create();
+        $shopName = $shop->getShopifySubdomain();
+    })->skip('Incomplete');
+});
+
+describe('authenticates new shop', function () {
+    it('creates new Shop and Access Token', function () {
+        $shopName = fake()->domainWord();
+
+        // This is not stored in DB, we just wanna use the factory definitions to create appropriate values
+        $fakeAccessToken = AccessToken::factory()->offline()->make();
+        $accessToken = [
+            'token' => $fakeAccessToken->token,
+            'expires_at' => $fakeAccessToken->expires_at,
+            'scopes' => $fakeAccessToken->scopes,
+            'refresh_token' => $fakeAccessToken->refresh_token,
+            'refresh_token_expires_at' => $fakeAccessToken->refresh_token_expires_at,
+        ];
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        // Mock that the request is valid
+        $mockShopify->shouldReceive('verifyAppHomeReq')
+            ->once()
+            ->andReturn(new ResultWithExchangeableIdToken(
+                ok: true,
+                shop: $shopName,
+                idToken: new IdToken(
+                    exchangeable: true,
+                    token: 'test_id_token',
+                    claims: ['sub' => '12345']
+                ),
+                userId: '12345',
+                newIdTokenResponse: null,
+                log: new LogWithReq(
+                    code: 'success',
+                    detail: 'Token verified',
+                    req: []
+                ),
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: []
+                )
+            ));
+
+        // Mock exchangeUsingTokenExchange-request
+        $mockShopify->shouldReceive('exchangeUsingTokenExchange')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: true,
+                shop: $shopName,
+                accessToken: new TokenExchangeAccessToken(
+                    accessMode: 'offline',
+                    shop: $shopName,
+                    token: $accessToken['token'],
+                    expires: $accessToken['expires_at']->toIso8601ZuluString(),
+                    scope: implode(',', $accessToken['scopes']),
+                    refreshToken: $accessToken['refresh_token'],
+                    refreshTokenExpires: $accessToken['refresh_token_expires_at']->toIso8601ZuluString(),
+                    user: null
+                ),
+                log: new Log(
+                    code: 'success',
+                    detail: 'Token exchanged'
+                ),
+                httpLogs: [],
+                response: new ResponseInfo(
+                    status: 200,
+                    body: '',
+                    headers: []
+                )
+            ));
+
+        $this->app->instance(ShopifyApp::class, $mockShopify);
+
+        $guard = Auth::guard('apphome');
+        $shop = $guard->user();
+
+        expect($guard->check())->toBeTrue() // Our "once" assumptions above checks that this check reuses the result from $quard->user()
+            ->and($shop)->toBeInstanceOf(Shop::class)
+            ->and($shop->shop_domain)->toBe($shopName.'.myshopify.com')
+            ->and($shop->accessToken)->toBeInstanceOf(AccessToken::class)
+            ->and($shop->accessToken->token)->toBe($accessToken['token'])
+            ->and($shop->accessToken->mode)->toBe(AccessTokenMode::Offline)
+            ->and($shop->accessToken->scopes)->toEqual($accessToken['scopes'])
+            ->and($shop->accessToken->expires_at)->toEqual($accessToken['expires_at'])
+            ->and($shop->accessToken->refresh_token)->toBe($accessToken['refresh_token'])
+            ->and($shop->accessToken->refresh_token_expires_at)->toEqual($accessToken['refresh_token_expires_at']);
+    });
+});

--- a/web/tests/Unit/ExampleTest.php
+++ b/web/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('that true is true', function () {
-    expect(true)->toBeTrue();
-});

--- a/web/tests/Unit/Models/Concerns/SearchableTest.php
+++ b/web/tests/Unit/Models/Concerns/SearchableTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Shop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+pest()->group('models', 'searchable');
+
+it('returns matching shops when searching by domain', function () {
+    Shop::factory()->create(['shop_domain' => 'matching-shop.myshopify.com']);
+    Shop::factory()->create(['shop_domain' => 'other-shop.myshopify.com']);
+
+    $results = Shop::search('matching');
+
+    expect($results)->toHaveCount(1)
+        ->and($results->first()->shop_domain)->toBe('matching-shop.myshopify.com');
+});
+
+it('returns matching shops when searching by name', function () {
+    Shop::factory()->create(['name' => 'Awesome Store']);
+    Shop::factory()->create(['name' => 'Regular Store']);
+
+    $results = Shop::search('Awesome');
+
+    expect($results)->toHaveCount(1)
+        ->and($results->first()->name)->toBe('Awesome Store');
+});
+
+it('returns matching shops when searching by email', function () {
+    Shop::factory()->create(['email' => 'hello@awesome.com']);
+    Shop::factory()->create(['email' => 'hello@regular.com']);
+
+    $results = Shop::search('awesome');
+
+    expect($results)->toHaveCount(1)
+        ->and($results->first()->email)->toBe('hello@awesome.com');
+});
+
+it('returns empty collection when no match is found', function () {
+    Shop::factory()->create(['shop_domain' => 'test.myshopify.com']);
+
+    $results = Shop::search('nonexistent');
+
+    expect($results)->toHaveCount(0);
+});
+
+it('returns all shops up to the limit when query is empty', function () {
+    Shop::factory()->count(3)->create();
+
+    $results = Shop::search('');
+
+    expect($results)->toHaveCount(3);
+});
+
+it('respects the limit parameter', function () {
+    Shop::factory()->count(5)->create();
+
+    $results = Shop::search('', limit: 2);
+
+    expect($results)->toHaveCount(2);
+});

--- a/web/tests/Unit/Services/Shopify/Exceptions/GraphQLRequestExceptionTest.php
+++ b/web/tests/Unit/Services/Shopify/Exceptions/GraphQLRequestExceptionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Services\Shopify\Exceptions\GraphQLRequestException;
+use App\Services\Shopify\Exceptions\ShopifyGraphQLExceptionInterface;
+use App\Services\Shopify\GraphQL\GraphQLError;
+use Shopify\App\Types\GQLResult;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+
+function failedGqlResult(string $logCode, string $body = ''): GQLResult
+{
+    return new GQLResult(
+        ok: false,
+        shop: 'test-shop.myshopify.com',
+        data: null,
+        extensions: null,
+        log: new Log(code: $logCode, detail: 'Request failed'),
+        httpLogs: [],
+        response: new ResponseInfo(status: 200, body: $body, headers: []),
+    );
+}
+
+describe('GraphQLRequestException', function () {
+    it('implements ShopifyGraphQLExceptionInterface', function () {
+        $exception = GraphQLRequestException::fromResult('shop.myshopify.com', failedGqlResult('network_error'));
+
+        expect($exception)->toBeInstanceOf(ShopifyGraphQLExceptionInterface::class);
+    });
+
+    it('stores shop domain and raw result', function () {
+        $result = failedGqlResult('network_error');
+        $exception = GraphQLRequestException::fromResult('test-shop.myshopify.com', $result);
+
+        expect($exception->getShopDomain())->toBe('test-shop.myshopify.com')
+            ->and($exception->getRawResult())->toBe($result);
+    });
+
+    it('parses errors from response body when log code is graphql_errors', function () {
+        $body = json_encode([
+            'errors' => [
+                ['message' => 'First error', 'extensions' => ['code' => 'ERROR_1']],
+                ['message' => 'Second error', 'extensions' => ['code' => 'ERROR_2']],
+            ],
+        ]);
+
+        $exception = GraphQLRequestException::fromResult('shop.myshopify.com', failedGqlResult('graphql_errors', $body));
+        $errors = $exception->getErrors();
+
+        expect($errors)->toHaveCount(2)
+            ->and($errors[0])->toBeInstanceOf(GraphQLError::class)
+            ->and($errors[0]->message)->toBe('First error')
+            ->and($errors[1]->message)->toBe('Second error')
+            ->and($exception->getMessage())->toBe('First error');
+    });
+
+    it('returns empty errors for non-graphql_errors codes', function () {
+        $exception = GraphQLRequestException::fromResult('shop.myshopify.com', failedGqlResult('unauthorized'));
+
+        expect($exception->getErrors())->toBe([])
+            ->and($exception->getMessage())->toBe('Request failed');
+    });
+
+    it('exposes log code', function () {
+        $exception = GraphQLRequestException::fromResult('shop.myshopify.com', failedGqlResult('rate_limited'));
+
+        expect($exception->getLogCode())->toBe('rate_limited');
+    });
+});

--- a/web/tests/Unit/Services/Shopify/Exceptions/ShopifyAuthExceptionTest.php
+++ b/web/tests/Unit/Services/Shopify/Exceptions/ShopifyAuthExceptionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Services\Shopify\Exceptions\ShopifyAuthException;
+use App\Services\Shopify\Exceptions\ShopifyAuthTransientException;
+use App\Services\Shopify\Exceptions\ShopifyInvalidClientException;
+use App\Services\Shopify\Exceptions\ShopifyInvalidGrantException;
+use App\Services\Shopify\Exceptions\ShopifyNetworkErrorException;
+use App\Services\Shopify\Exceptions\ShopifyReauthRequiredException;
+use App\Services\Shopify\Exceptions\ShopifyRefreshTokenExpiredException;
+use App\Services\Shopify\Exceptions\ShopifyServerErrorException;
+use App\Services\Shopify\Exceptions\ShopifyUnexpectedAuthException;
+use Illuminate\Http\Request;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+use Shopify\App\Types\TokenExchangeResult;
+
+function makeResult(string $code, int $status = 500): TokenExchangeResult
+{
+    return new TokenExchangeResult(
+        ok: false,
+        shop: 'example',
+        accessToken: null,
+        log: new Log(code: $code, detail: "detail for {$code}"),
+        httpLogs: [],
+        response: new ResponseInfo(status: $status, body: '', headers: (object) []),
+    );
+}
+
+describe('ShopifyAuthException::fromResult', function () {
+    test('maps each known log_code to its concrete exception', function (string $code, string $class) {
+        $e = ShopifyAuthException::fromResult(makeResult($code));
+
+        expect($e)->toBeInstanceOf($class)
+            ->and($e->result->log->code)->toBe($code)
+            ->and($e->getMessage())->toContain($code)
+            ->and($e->getMessage())->toContain("detail for {$code}");
+    })->with([
+        ['refresh_token_expired', ShopifyRefreshTokenExpiredException::class],
+        ['invalid_grant', ShopifyInvalidGrantException::class],
+        ['invalid_client', ShopifyInvalidClientException::class],
+        ['network_error', ShopifyNetworkErrorException::class],
+        ['server_error', ShopifyServerErrorException::class],
+    ]);
+
+    test('falls back to ShopifyUnexpectedAuthException for unknown codes', function (string $code) {
+        $e = ShopifyAuthException::fromResult(makeResult($code));
+
+        expect($e)->toBeInstanceOf(ShopifyUnexpectedAuthException::class);
+    })->with([
+        'configuration_error',
+        'refresh_error',
+        'unexpected_error',
+        'something_brand_new_in_the_package',
+    ]);
+
+    test('context() exposes the package log + response info', function () {
+        $e = ShopifyAuthException::fromResult(makeResult('network_error'));
+
+        expect($e->context())->toMatchArray([
+            'shop_id' => null,
+            'shop_domain' => null,
+            'log_code' => 'network_error',
+            'log_detail' => 'detail for network_error',
+            'response_status' => 500,
+        ]);
+    });
+});
+
+describe('reauth-required exceptions', function () {
+    test('render() returns 401 with App Bridge reauthorize headers', function () {
+        $e = new ShopifyRefreshTokenExpiredException(makeResult('refresh_token_expired', 401));
+
+        $response = $e->render(Request::create('/'));
+
+        expect($response->getStatusCode())->toBe(401)
+            ->and($response->headers->get('X-Shopify-API-Request-Failure-Reauthorize'))->toBe('1')
+            ->and($response->headers->get('X-Shopify-API-Request-Failure-Reauthorize-Url'))->not->toBeEmpty();
+    });
+
+    test('share the reauth base type for polymorphic catches', function (string $class) {
+        $e = new $class(makeResult('refresh_token_expired'));
+
+        expect($e)->toBeInstanceOf(ShopifyReauthRequiredException::class);
+    })->with([
+        ShopifyRefreshTokenExpiredException::class,
+        ShopifyInvalidGrantException::class,
+        ShopifyInvalidClientException::class,
+    ]);
+
+    test('report() returns false so Laravel skips default reporting', function () {
+        $e = new ShopifyInvalidGrantException(makeResult('invalid_grant'));
+
+        expect($e->report())->toBeFalse();
+    });
+});
+
+describe('transient exceptions', function () {
+    test('return null in non-production so APP_DEBUG/Ignition handles them', function () {
+        app()->detectEnvironment(fn () => 'local');
+        $e = new ShopifyNetworkErrorException(makeResult('network_error'));
+
+        expect($e->render(Request::create('/')))->toBeNull();
+    });
+
+    test('return 503 + Retry-After in production', function () {
+        app()->detectEnvironment(fn () => 'production');
+        $e = new ShopifyServerErrorException(makeResult('server_error'));
+
+        $response = $e->render(Request::create('/'));
+
+        expect($response->getStatusCode())->toBe(503)
+            ->and($response->headers->get('Retry-After'))->toBe('30');
+    });
+
+    test('share the transient base type for polymorphic catches', function () {
+        expect(new ShopifyNetworkErrorException(makeResult('network_error')))
+            ->toBeInstanceOf(ShopifyAuthTransientException::class)
+            ->and(new ShopifyServerErrorException(makeResult('server_error')))
+            ->toBeInstanceOf(ShopifyAuthTransientException::class);
+    });
+});

--- a/web/tests/Unit/Services/Shopify/GraphQL/GraphQLErrorTest.php
+++ b/web/tests/Unit/Services/Shopify/GraphQL/GraphQLErrorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Services\Shopify\GraphQL\GraphQLError;
+
+describe('GraphQLError', function () {
+    it('creates from array', function () {
+        $data = [
+            'message' => 'Field not found',
+            'locations' => [['line' => 1, 'column' => 5]],
+            'path' => ['shop', 'name'],
+            'extensions' => ['code' => 'ACCESS_DENIED'],
+        ];
+
+        $error = GraphQLError::fromArray($data);
+
+        expect($error->message)->toBe('Field not found')
+            ->and($error->locations)->toBe([['line' => 1, 'column' => 5]])
+            ->and($error->path)->toBe(['shop', 'name'])
+            ->and($error->extensions)->toBe(['code' => 'ACCESS_DENIED']);
+    });
+
+    it('handles missing values', function () {
+        $error = GraphQLError::fromArray([]);
+
+        expect($error->message)->toBe('')
+            ->and($error->locations)->toBeNull()
+            ->and($error->path)->toBeNull()
+            ->and($error->extensions)->toBeNull();
+    });
+
+    it('extracts code from extensions', function () {
+        $error = GraphQLError::fromArray([
+            'message' => 'Error',
+            'extensions' => ['code' => 'THROTTLED'],
+        ]);
+
+        expect($error->getCode())->toBe('THROTTLED');
+    });
+
+    it('returns null code when extensions is null', function () {
+        $error = GraphQLError::fromArray([
+            'message' => 'Error',
+        ]);
+
+        expect($error->getCode())->toBeNull();
+    });
+
+    it('returns null code when code is missing from extensions', function () {
+        $error = GraphQLError::fromArray([
+            'message' => 'Error',
+            'extensions' => ['other' => 'value'],
+        ]);
+
+        expect($error->getCode())->toBeNull();
+    });
+});

--- a/web/tests/Unit/Services/Shopify/GraphQL/ShopifyGraphQLClientTest.php
+++ b/web/tests/Unit/Services/Shopify/GraphQL/ShopifyGraphQLClientTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Services\Shopify\Exceptions\GraphQLRequestException;
+use App\Services\Shopify\GraphQL\ShopifyGraphQLClient;
+use App\Services\Shopify\GraphQL\ShopifyGraphQLResult;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\GQLResult;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+
+function makeClientResult(
+    bool $ok = true,
+    ?array $data = [],
+    ?array $extensions = null,
+    ?string $logCode = 'success',
+    ?string $logDetail = '',
+    string $body = '',
+): GQLResult {
+    return new GQLResult(
+        ok: $ok,
+        shop: 'test-shop.myshopify.com',
+        data: $data,
+        extensions: $extensions,
+        log: new Log(code: $logCode ?? 'success', detail: $logDetail ?? ''),
+        httpLogs: [],
+        response: new ResponseInfo(status: $ok ? 200 : 401, body: $body, headers: []),
+    );
+}
+
+function makeClient(ShopifyApp $shopifyApp, ?Closure $refresher = null): ShopifyGraphQLClient
+{
+    return new ShopifyGraphQLClient(
+        shopifyApp: $shopifyApp,
+        shopDomain: 'test-shop.myshopify.com',
+        accessToken: 'initial-token',
+        apiVersion: '2025-01',
+        refresher: $refresher ?? fn (): string => 'refreshed-token',
+    );
+}
+
+describe('ShopifyGraphQLClient', function () {
+    it('executes query and returns result', function () {
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->once()
+            ->andReturn(makeClientResult(data: ['shop' => ['name' => 'Test Shop']]));
+
+        $result = makeClient($shopifyApp)->query('{ shop { name } }');
+
+        expect($result)->toBeInstanceOf(ShopifyGraphQLResult::class)
+            ->and($result->data())->toBe(['shop' => ['name' => 'Test Shop']]);
+    });
+
+    it('passes variables through to the package', function () {
+        $captured = null;
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->once()
+            ->withArgs(function (...$args) use (&$captured) {
+                $captured = $args[5] ?? null;
+
+                return true;
+            })
+            ->andReturn(makeClientResult(data: ['order' => ['id' => '123']]));
+
+        makeClient($shopifyApp)->query('query Q($id: ID!) { order(id: $id) { id } }', ['id' => 'gid://shopify/Order/123']);
+
+        expect($captured)->toBe(['id' => 'gid://shopify/Order/123']);
+    });
+
+    it('throws GraphQLRequestException on non-recoverable failure', function () {
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->once()
+            ->andReturn(makeClientResult(ok: false, data: null, logCode: 'network_error', logDetail: 'Connection timeout'));
+
+        makeClient($shopifyApp)->query('{ shop { name } }');
+    })->throws(GraphQLRequestException::class, 'Connection timeout');
+
+    it('refreshes token and retries once on unauthorized', function () {
+        $tokensUsed = [];
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->twice()
+            ->withArgs(function (...$args) use (&$tokensUsed) {
+                $tokensUsed[] = $args[2] ?? null;
+
+                return true;
+            })
+            ->andReturnValues([
+                makeClientResult(ok: false, data: null, logCode: 'unauthorized', logDetail: 'Token invalid'),
+                makeClientResult(data: ['shop' => ['name' => 'Test Shop']]),
+            ]);
+
+        $refresherCalled = false;
+        $client = makeClient($shopifyApp, function () use (&$refresherCalled): string {
+            $refresherCalled = true;
+
+            return 'refreshed-token';
+        });
+
+        $result = $client->query('{ shop { name } }');
+
+        expect($refresherCalled)->toBeTrue()
+            ->and($tokensUsed)->toBe(['initial-token', 'refreshed-token'])
+            ->and($result->data())->toBe(['shop' => ['name' => 'Test Shop']]);
+    });
+
+    it('throws if still unauthorized after refresh', function () {
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->twice()
+            ->andReturn(makeClientResult(ok: false, data: null, logCode: 'unauthorized', logDetail: 'Token invalid'));
+
+        makeClient($shopifyApp)->query('{ shop { name } }');
+    })->throws(GraphQLRequestException::class);
+
+    it('mutate is an alias for query', function () {
+        $shopifyApp = Mockery::mock(ShopifyApp::class);
+        $shopifyApp->shouldReceive('adminGraphQLRequest')
+            ->once()
+            ->andReturn(makeClientResult(data: ['productCreate' => ['product' => ['id' => '123']]]));
+
+        $result = makeClient($shopifyApp)->mutate('mutation { productCreate(input: {}) { product { id } } }');
+
+        expect($result)->toBeInstanceOf(ShopifyGraphQLResult::class);
+    });
+
+    it('returns shop domain', function () {
+        $client = makeClient(Mockery::mock(ShopifyApp::class));
+
+        expect($client->getShopDomain())->toBe('test-shop.myshopify.com');
+    });
+});

--- a/web/tests/Unit/Services/Shopify/GraphQL/ShopifyGraphQLResultTest.php
+++ b/web/tests/Unit/Services/Shopify/GraphQL/ShopifyGraphQLResultTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Services\Shopify\GraphQL\ShopifyGraphQLResult;
+use App\Services\Shopify\GraphQL\ThrottleStatus;
+use Shopify\App\Types\GQLResult;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+
+function makeGqlResult(?array $data = [], ?array $extensions = null): GQLResult
+{
+    return new GQLResult(
+        ok: true,
+        shop: 'test-shop.myshopify.com',
+        data: $data,
+        extensions: $extensions,
+        log: new Log(code: 'success', detail: ''),
+        httpLogs: [],
+        response: new ResponseInfo(status: 200, body: '', headers: []),
+    );
+}
+
+describe('ShopifyGraphQLResult', function () {
+    it('returns data from result', function () {
+        $result = new ShopifyGraphQLResult(makeGqlResult(data: ['shop' => ['name' => 'Test Shop']]));
+
+        expect($result->data())->toBe(['shop' => ['name' => 'Test Shop']]);
+    });
+
+    it('returns empty array when data is null', function () {
+        $result = new ShopifyGraphQLResult(makeGqlResult(data: null));
+
+        expect($result->data())->toBe([]);
+    });
+
+    it('parses throttle status from extensions', function () {
+        $result = new ShopifyGraphQLResult(makeGqlResult(extensions: [
+            'cost' => [
+                'throttleStatus' => [
+                    'maximumAvailable' => 2000,
+                    'currentlyAvailable' => 1500,
+                    'restoreRate' => 100.0,
+                ],
+            ],
+        ]));
+
+        $throttle = $result->throttleStatus();
+
+        expect($throttle)->toBeInstanceOf(ThrottleStatus::class)
+            ->and($throttle->maximumAvailable)->toBe(2000)
+            ->and($throttle->currentlyAvailable)->toBe(1500);
+    });
+
+    it('returns null throttle status when not present', function () {
+        $result = new ShopifyGraphQLResult(makeGqlResult());
+
+        expect($result->throttleStatus())->toBeNull();
+    });
+
+    it('provides access to raw result', function () {
+        $gqlResult = makeGqlResult();
+
+        $result = new ShopifyGraphQLResult($gqlResult);
+
+        expect($result->raw())->toBe($gqlResult);
+    });
+});

--- a/web/tests/Unit/Services/Shopify/GraphQL/ThrottleStatusTest.php
+++ b/web/tests/Unit/Services/Shopify/GraphQL/ThrottleStatusTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Services\Shopify\GraphQL\ThrottleStatus;
+
+describe('ThrottleStatus', function () {
+    it('creates from array', function () {
+        $data = [
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 1500,
+            'restoreRate' => 100.0,
+        ];
+
+        $status = ThrottleStatus::fromArray($data);
+
+        expect($status->maximumAvailable)->toBe(2000)
+            ->and($status->currentlyAvailable)->toBe(1500)
+            ->and($status->restoreRate)->toBe(100.0);
+    });
+
+    it('returns null when data is null', function () {
+        expect(ThrottleStatus::fromArray(null))->toBeNull();
+    });
+
+    it('handles missing values with defaults', function () {
+        $status = ThrottleStatus::fromArray([]);
+
+        expect($status->maximumAvailable)->toBe(0)
+            ->and($status->currentlyAvailable)->toBe(0)
+            ->and($status->restoreRate)->toBe(0.0);
+    });
+
+    it('detects low availability', function () {
+        $lowStatus = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 50,
+            'restoreRate' => 100.0,
+        ]);
+
+        $highStatus = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 500,
+            'restoreRate' => 100.0,
+        ]);
+
+        expect($lowStatus->isLow())->toBeTrue()
+            ->and($highStatus->isLow())->toBeFalse();
+    });
+
+    it('allows custom threshold for isLow', function () {
+        $status = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 200,
+            'restoreRate' => 100.0,
+        ]);
+
+        expect($status->isLow(100))->toBeFalse()
+            ->and($status->isLow(300))->toBeTrue();
+    });
+
+    it('calculates wait time in milliseconds', function () {
+        $status = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 50,
+            'restoreRate' => 50.0,
+        ]);
+
+        // Need 50 more points to reach 100, at 50 points/second = 1 second = 1000ms
+        expect($status->getWaitMilliseconds(100))->toBe(1000);
+    });
+
+    it('returns zero wait time when enough points available', function () {
+        $status = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 500,
+            'restoreRate' => 100.0,
+        ]);
+
+        expect($status->getWaitMilliseconds(100))->toBe(0);
+    });
+
+    it('returns zero wait time when restore rate is zero', function () {
+        $status = ThrottleStatus::fromArray([
+            'maximumAvailable' => 2000,
+            'currentlyAvailable' => 50,
+            'restoreRate' => 0.0,
+        ]);
+
+        expect($status->getWaitMilliseconds(100))->toBe(0);
+    });
+});

--- a/web/tests/Unit/Services/Shopify/ShopifyAppTest.php
+++ b/web/tests/Unit/Services/Shopify/ShopifyAppTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Shopify\App\ShopifyApp;
+
+describe('ShopifyApp resolving ', function () {
+    it('resolves from the container', function () {
+        config([
+            'shopify.client_id' => 'test-client-id',
+            'shopify.client_secret' => 'test-client-secret',
+        ]);
+
+        $shopify = app(ShopifyApp::class);
+
+        // The ShopifyApp class doesn't expose its config, but we can verify
+        // it was instantiated without errors, meaning the config was valid
+        expect($shopify)->toBeInstanceOf(ShopifyApp::class);
+    });
+
+    it('resolves as a singleton', function () {
+        config([
+            'shopify.client_id' => 'test-client-id',
+            'shopify.client_secret' => 'test-client-secret',
+        ]);
+
+        $instance1 = app(ShopifyApp::class);
+        $instance2 = app(ShopifyApp::class);
+
+        expect($instance1 === $instance2)->toBeTrue(); // strict comparison
+    });
+
+    it('throws exception when client_id is missing', function () {
+        config([
+            'shopify.client_id' => null,
+            'shopify.client_secret' => 'test-client-secret',
+        ]);
+
+        app(ShopifyApp::class);
+    })->throws(TypeError::class);
+
+    it('throws exception when client_secret is missing', function () {
+        config([
+            'shopify.client_id' => 'test-client-id',
+            'shopify.client_secret' => null,
+        ]);
+
+        app(ShopifyApp::class);
+    })->throws(InvalidArgumentException::class, 'clientSecret is required');
+});

--- a/web/tests/Unit/Services/Shopify/ShopifyRequestConverterTest.php
+++ b/web/tests/Unit/Services/Shopify/ShopifyRequestConverterTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use App\Services\Shopify\ShopifyRequestConverter;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Shopify\App\Types\LogWithReq;
+use Shopify\App\Types\ResponseInfo;
+
+pest()->group('services', 'shopify');
+
+describe('toShopifyRequest', function () {
+    it('converts a Laravel request to Shopify request format', function () {
+        $request = Request::create(
+            uri: 'https://example.com/test?foo=bar',
+            method: 'POST',
+            content: '{"data": "test"}',
+        );
+        $request->headers->set('Authorization', 'Bearer token123');
+        $request->headers->set('Content-Type', 'application/json');
+
+        $result = ShopifyRequestConverter::toShopifyRequest($request);
+
+        expect($result)->toBeArray()
+            ->and($result['method'])->toBe('POST')
+            ->and($result['url'])->toBe('https://example.com/test?foo=bar')
+            ->and($result['body'])->toBe('{"data": "test"}')
+            ->and($result['headers'])->toBeArray();
+    });
+
+    it('includes all headers as single string values', function () {
+        // shopify-app-php expects one string per header (e.g. when comparing
+        // the X-Shopify-Hmac-SHA256 header), not Laravel's array of values.
+        $request = Request::create(
+            uri: 'https://example.com/test',
+            method: 'GET',
+        );
+        $request->headers->set('X-Custom-Header', 'custom-value');
+
+        $result = ShopifyRequestConverter::toShopifyRequest($request);
+
+        expect($result['headers']['x-custom-header'])->toBe('custom-value');
+    });
+
+    it('joins multi-value headers with a comma', function () {
+        $request = Request::create(
+            uri: 'https://example.com/test',
+            method: 'GET',
+        );
+        $request->headers->set('X-Multi-Header', ['first', 'second']);
+
+        $result = ShopifyRequestConverter::toShopifyRequest($request);
+
+        expect($result['headers']['x-multi-header'])->toBe('first, second');
+    });
+
+    it('handles GET requests with empty body', function () {
+        $request = Request::create(
+            uri: 'https://example.com/path',
+            method: 'GET',
+        );
+
+        $result = ShopifyRequestConverter::toShopifyRequest($request);
+
+        expect($result['method'])->toBe('GET')
+            ->and($result['body'])->toBe('');
+    });
+
+    it('includes the full URL with query parameters', function () {
+        $request = Request::create(
+            uri: 'https://example.com/auth?shop=test.myshopify.com&code=abc123',
+            method: 'GET',
+        );
+
+        $result = ShopifyRequestConverter::toShopifyRequest($request);
+
+        // Query parameters may be reordered, so just check they're present
+        expect($result['url'])->toContain('https://example.com/auth')
+            ->and($result['url'])->toContain('shop=test.myshopify.com')
+            ->and($result['url'])->toContain('code=abc123');
+    });
+});
+
+describe('toResponse', function () {
+    it('converts ResponseInfo to Laravel Response', function () {
+        $responseInfo = new ResponseInfo(
+            status: 200,
+            body: '<html>Test</html>',
+            headers: ['Content-Type' => 'text/html'],
+        );
+        $log = new LogWithReq(
+            code: 'success',
+            detail: 'Request successful',
+            req: [],
+        );
+
+        Log::spy();
+
+        $response = ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        expect($response->getStatusCode())->toBe(200)
+            ->and($response->getContent())->toBe('<html>Test</html>')
+            ->and($response->headers->get('Content-Type'))->toBe('text/html');
+    });
+
+    it('handles multiple headers', function () {
+        $responseInfo = new ResponseInfo(
+            status: 200,
+            body: 'test',
+            headers: [
+                'Content-Type' => 'text/plain',
+                'X-Custom' => 'value',
+                'X-Another' => 'another-value',
+            ],
+        );
+        $log = new LogWithReq(code: 'test', detail: 'test', req: []);
+
+        Log::spy();
+
+        $response = ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        expect($response->headers->get('Content-Type'))->toBe('text/plain')
+            ->and($response->headers->get('X-Custom'))->toBe('value')
+            ->and($response->headers->get('X-Another'))->toBe('another-value');
+    });
+
+    it('handles object headers', function () {
+        $responseInfo = new ResponseInfo(
+            status: 400,
+            body: 'Bad Request',
+            headers: (object) ['X-Error' => 'true'],
+        );
+        $log = new LogWithReq(code: 'error', detail: 'Bad request', req: []);
+
+        Log::spy();
+
+        $response = ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        expect($response->getStatusCode())->toBe(400)
+            ->and($response->headers->get('X-Error'))->toBe('true');
+    });
+
+    it('handles empty headers object', function () {
+        $responseInfo = new ResponseInfo(
+            status: 500,
+            body: 'Internal Server Error',
+            headers: (object) [],
+        );
+        $log = new LogWithReq(code: 'error', detail: 'Server error', req: []);
+
+        Log::spy();
+
+        $response = ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        expect($response->getStatusCode())->toBe(500)
+            ->and($response->getContent())->toBe('Internal Server Error');
+    });
+
+    it('logs the conversion', function () {
+        Log::spy();
+
+        $responseInfo = new ResponseInfo(
+            status: 200,
+            body: 'test',
+            headers: [],
+        );
+        $log = new LogWithReq(
+            code: 'test_code',
+            detail: 'Test detail message',
+            req: [],
+        );
+
+        ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->with('Converting Shopify ResponseInfo to Response', [
+                'code' => 'test_code',
+                'detail' => 'Test detail message',
+            ]);
+    });
+
+    it('returns different status codes correctly', function (int $status) {
+        $responseInfo = new ResponseInfo(
+            status: $status,
+            body: 'test',
+            headers: [],
+        );
+        $log = new LogWithReq(code: 'test', detail: 'test', req: []);
+
+        Log::spy();
+
+        $response = ShopifyRequestConverter::toResponse($responseInfo, $log);
+
+        expect($response->getStatusCode())->toBe($status);
+    })->with([200, 201, 400, 401, 403, 404, 500]);
+});

--- a/web/tests/Unit/Services/Shopify/ShopifyShopTest.php
+++ b/web/tests/Unit/Services/Shopify/ShopifyShopTest.php
@@ -1,0 +1,246 @@
+<?php
+
+use App\Actions\RefreshAccessTokenAction;
+use App\Models\AccessToken;
+use App\Models\Shop;
+use App\Services\Shopify\Exceptions\AccessTokenStillValidException;
+use App\Services\Shopify\Exceptions\MissingAccessTokenException;
+use App\Services\Shopify\Exceptions\MissingApiVersionException;
+use App\Services\Shopify\Exceptions\ShopifyServerErrorException;
+use App\Services\Shopify\GraphQL\ShopifyGraphQLClient;
+use App\Services\Shopify\ShopifyShop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Shopify\App\ShopifyApp;
+use Shopify\App\Types\Log;
+use Shopify\App\Types\ResponseInfo;
+use Shopify\App\Types\TokenExchangeAccessToken;
+use Shopify\App\Types\TokenExchangeResult;
+
+uses(RefreshDatabase::class);
+
+pest()->group('services', 'shopify');
+
+function createShopifyShop(Shop $shop, ?ShopifyApp $shopifyApp = null): ShopifyShop
+{
+    return new ShopifyShop(
+        shop: $shop,
+        shopifyApp: $shopifyApp ?? Mockery::mock(ShopifyApp::class),
+    );
+}
+
+describe('isAccessTokenValid', function () {
+    it('returns false when shop has no access token', function () {
+        $shop = Shop::factory()->create();
+
+        expect(createShopifyShop($shop)->isAccessTokenValid())->toBeFalse();
+    });
+
+    it('returns true when access token has no expiry', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->isAccessTokenValid())->toBeTrue();
+    });
+
+    it('returns true when access token is not expired', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create(['expires_at' => now()->addHours(2)]);
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->isAccessTokenValid())->toBeTrue();
+    });
+
+    it('returns false when access token is expired', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->expired()->create();
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->isAccessTokenValid())->toBeFalse();
+    });
+});
+
+describe('shouldAccessTokenBeRefreshed', function () {
+    it('returns false when shop has no access token', function () {
+        expect(createShopifyShop(Shop::factory()->create())->shouldAccessTokenBeRefreshed())->toBeFalse();
+    });
+
+    it('returns false when access token has no expiry', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->shouldAccessTokenBeRefreshed())->toBeFalse();
+    });
+
+    it('returns false when access token expires far in the future', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create([
+            'expires_at' => now()->addDays(30),
+            'refresh_token_expires_at' => now()->addDays(90),
+        ]);
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->shouldAccessTokenBeRefreshed())->toBeFalse();
+    });
+
+    it('returns true when access token is expired', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->expired()->create();
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->shouldAccessTokenBeRefreshed())->toBeTrue();
+    });
+
+    it('returns true when access token expires within threshold', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create(['expires_at' => now()->addMinutes(30)]);
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->shouldAccessTokenBeRefreshed(thresholdMinutes: 60))->toBeTrue();
+    });
+
+    it('returns true when refresh token expires within threshold', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create([
+            'expires_at' => now()->addDays(30),
+            'refresh_token_expires_at' => now()->addMinutes(30),
+        ]);
+        $shop->refresh();
+
+        expect(createShopifyShop($shop)->shouldAccessTokenBeRefreshed(thresholdMinutes: 60))->toBeTrue();
+    });
+});
+
+describe('refreshAccessToken', function () {
+    it('throws MissingAccessTokenException when shop has no access token', function () {
+        createShopifyShop(Shop::factory()->create())->refreshAccessToken();
+    })->throws(MissingAccessTokenException::class);
+
+    it('throws a typed ShopifyAuthException matching the refresh log_code', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create();
+        $shop->refresh();
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('refreshTokenExchangedAccessToken')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: false,
+                shop: $shop->getShopifySubdomain(),
+                accessToken: null,
+                log: new Log(code: 'server_error', detail: 'Internal server error'),
+                httpLogs: [],
+                response: new ResponseInfo(status: 500, body: 'Server Error', headers: (object) []),
+            ));
+
+        createShopifyShop($shop, $mockShopify)->refreshAccessToken();
+    })->throws(ShopifyServerErrorException::class);
+
+    it('throws AccessTokenStillValidException when token is still valid', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create();
+        $shop->refresh();
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('refreshTokenExchangedAccessToken')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: true,
+                shop: $shop->getShopifySubdomain(),
+                accessToken: null,
+                log: new Log(code: 'token_still_valid', detail: 'Access token is still valid.'),
+                httpLogs: [],
+                response: new ResponseInfo(status: 200, body: '', headers: (object) []),
+            ));
+
+        createShopifyShop($shop, $mockShopify)->refreshAccessToken();
+    })->throws(AccessTokenStillValidException::class);
+
+    it('returns new TokenExchangeAccessToken on successful refresh', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create();
+        $shop->refresh();
+
+        $newToken = new TokenExchangeAccessToken(
+            accessMode: 'offline',
+            shop: $shop->getShopifySubdomain(),
+            token: 'shpat_new_token',
+            expires: '2026-12-31T23:59:59Z',
+            scope: 'read_products,write_orders',
+            refreshToken: 'shprt_new_refresh',
+            refreshTokenExpires: '2027-06-30T23:59:59Z',
+            user: null,
+        );
+
+        $mockShopify = Mockery::mock(ShopifyApp::class);
+        $mockShopify->shouldReceive('refreshTokenExchangedAccessToken')
+            ->once()
+            ->andReturn(new TokenExchangeResult(
+                ok: true,
+                shop: $shop->getShopifySubdomain(),
+                accessToken: $newToken,
+                log: new Log(code: 'success', detail: 'Token refresh successful.'),
+                httpLogs: [],
+                response: new ResponseInfo(status: 200, body: '', headers: (object) []),
+            ));
+
+        $result = createShopifyShop($shop, $mockShopify)->refreshAccessToken();
+
+        expect($result)->toBe($newToken)
+            ->and($result->token)->toBe('shpat_new_token');
+    });
+});
+
+describe('graphql', function () {
+    it('throws MissingAccessTokenException when shop has no access token', function () {
+        createShopifyShop(Shop::factory()->create())->graphql();
+    })->throws(MissingAccessTokenException::class);
+
+    it('throws MissingApiVersionException when the configured api version is empty', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+        $shop->refresh();
+
+        config(['shopify.api_version' => '']);
+
+        createShopifyShop($shop)->graphql();
+    })->throws(MissingApiVersionException::class);
+
+    it('returns a ShopifyGraphQLClient bound to the shop', function () {
+        $shop = Shop::factory()->create(['shop_domain' => 'demo.myshopify.com']);
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+        $shop->refresh();
+
+        config(['shopify.api_version' => '2025-01']);
+
+        $client = createShopifyShop($shop)->graphql();
+
+        expect($client)->toBeInstanceOf(ShopifyGraphQLClient::class)
+            ->and($client->getShopDomain())->toBe('demo');
+    });
+
+    it('caches the client across calls', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offlineNonExpiring()->create();
+        $shop->refresh();
+
+        $service = createShopifyShop($shop);
+
+        expect($service->graphql())->toBe($service->graphql());
+    });
+
+    it('proactively triggers a refresh when token is near expiry', function () {
+        $shop = Shop::factory()->create();
+        AccessToken::factory()->for($shop)->offline()->create(['expires_at' => now()->addSeconds(30)]);
+        $shop->refresh();
+
+        $action = Mockery::mock(RefreshAccessTokenAction::class);
+        $action->shouldReceive('execute')->once()->with($shop)->andReturn($shop->accessToken);
+        app()->instance(RefreshAccessTokenAction::class, $action);
+
+        config(['shopify.api_version' => '2025-01']);
+
+        createShopifyShop($shop)->graphql();
+    });
+});


### PR DESCRIPTION
## Why

The template's README advertised `Shopify/shopify-app-php` integration for *"request verification, token handling, GraphQL and helper functions"* — but the package wasn't even a dependency, and none of that boilerplate existed. The template was a bare Laravel app + one CSP middleware.

Meanwhile the Smart Send app (built from this template) independently grew a complete, production-grade boilerplate layer. This PR extracts the **generic, app-agnostic** slice of it back into the template so the template actually is the complete starting point it claims to be.

## Scope decisions

- **Backend boilerplate only** — the template keeps its existing **Blade + App Bridge** frontend. No Inertia/React port, no feature pages.
- **Batteries-included** — full auth + token lifecycle, all four mandatory webhook handlers + dedup, the complete Shopify exception hierarchy, request-id error references, models/migrations, and an accompanying test suite.
- Smart Send **feature code is excluded** (packages, carriers, orders, fulfillments, metafields, the SmartSend client). The first-install hook in the guard is left as a documented extension point.

## What's added

- **Embedded App Home auth** — `ShopifyAppHomeGuard` (token exchange), `VerifyShopifyAppHome` middleware (App Bridge recovery responses), `/auth/patch-id-token` route, `apphome` guard + `shops` provider.
- **Offline token storage + refresh** — `Shop` + `AccessToken` models and migrations; proactive + reactive (401) refresh in `ShopifyShop`.
- **GraphQL client** — `$shop->shopify()->graphql()` with throttle handling + typed errors; `details()` as a worked example.
- **Webhook pipeline** — single canonical `POST /webhooks/shopify`, HMAC verify, `WebhookDispatcher` with dedup, and the 4 mandatory handlers (`app/uninstalled` + 3 GDPR topics). Subscriptions declared in `shopify.app.toml`.
- **Error references** — `AssignRequestIdMiddleware` + Blade `errors/500.blade.php`.
- **Tests** — Unit + Feature suite (auth, webhooks, token refresh, GraphQL, exceptions) + opt-in Contract tier.
- **Config** — `shopify-app-php` dependency, `.env.example` Shopify vars, `webhooks_path` aligned to `/webhooks/shopify`.

## Verification

- `php artisan migrate:fresh` → only `shops` + `access_tokens` (no feature tables).
- `php artisan test` → **194 passed, 1 skipped** (an intentionally-incomplete test), 0 failures.
- `php artisan test --testsuite=Contract` → self-skips cleanly without a dev store.
- `grep -ri smartsend app config routes tests database` → nothing.
- `php artisan route:list` → `/` (auth group), `/auth/patch-id-token`, `POST /webhooks/shopify` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)